### PR TITLE
feat: add support for arc clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,3 @@
 # binary output
 bin/
 hack/tools/bin/
-
-# test configurations
-azure.json

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -41,15 +41,15 @@ jobs:
       matrix:
         aks_linux:
           REGISTRY: upstreamk8sci.azurecr.io/aad-pod-managed-identity
+          # we can enable actual tenant id for functional e2e
+          AZURE_TENANT_ID: "fake tenant id"
         kind_v1_19_7:
           KIND_NODE_VERSION: v1.19.7
           LOCAL_ONLY: "true"
-          AZURE_SUBSCRIPTION_ID: "fake subscription id"
           AZURE_TENANT_ID: "fake tenant id"
         kind_v1_20_2:
           KIND_NODE_VERSION: v1.20.2
           LOCAL_ONLY: "true"
-          AZURE_SUBSCRIPTION_ID: "fake subscription id"
           AZURE_TENANT_ID: "fake tenant id"
     steps:
       - script: make test-e2e

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -18,6 +19,13 @@ func init() {
 }
 
 func main() {
+	var arcCluster bool
+
+	// TODO (aramase) once webhook is added as an arc extension, use extension
+	// util to check if running in arc cluster.
+	flag.BoolVar(&arcCluster, "arc-cluster", false, "Running on arc cluster")
+	flag.Parse()
+
 	entryLog := log.Log.WithName("entrypoint")
 
 	// Setup a manager
@@ -33,7 +41,7 @@ func main() {
 	hookServer := mgr.GetWebhookServer()
 
 	entryLog.Info("registering webhook to the webhook server")
-	podMutator, err := wh.NewPodMutator(mgr.GetClient())
+	podMutator, err := wh.NewPodMutator(mgr.GetClient(), arcCluster)
 	if err != nil {
 		entryLog.Error(err, "unable to set up pod mutator")
 		os.Exit(1)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,8 +25,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --enable-leader-election
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager
@@ -37,14 +35,6 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
-        securityContext:
-          runAsUser: 0
-        volumeMounts:
-          - name: azure-config
-            mountPath: /etc/kubernetes/azure.json
-            readOnly: true
-      volumes:
-        - name: azure-config
-          hostPath:
-            path: /etc/kubernetes/azure.json
-            type: FileOrCreate
+        envFrom:
+          - configMapRef:
+              name: aad-pi-config 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.16
 
 require (
 	github.com/Azure/go-autorest/autorest v0.11.1
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.11.0
 	github.com/pkg/errors v0.9.1
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/klog/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,35 +1,23 @@
 package config
 
 import (
-	"os"
-
+	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 )
 
-// Config holds configuration from azure.json
+// Config holds configuration from the env variables
 type Config struct {
-	Cloud          string `json:"cloud" yaml:"cloud"`
-	TenantID       string `json:"tenantId" yaml:"tenantId"`
-	SubscriptionID string `json:"subscriptionId" yaml:"subscriptionId"`
+	Cloud    string `envconfig:"AZURE_ENVIRONMENT"`
+	TenantID string `envconfig:"AZURE_TENANT_ID"`
 }
 
-// ParseConfig parses the configuration from azure.json or env variables
-func ParseConfig(configFile string) (*Config, error) {
+// ParseConfig parses the configuration from env variables
+func ParseConfig() (*Config, error) {
 	c := new(Config)
-	if configFile != "" {
-		bytes, err := os.ReadFile(configFile)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to read config file %s", configFile)
-		}
-		if err = yaml.Unmarshal(bytes, &c); err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal JSON")
-		}
-	} else {
-		c.Cloud = os.Getenv("AZURE_ENVIRONMENT")
-		c.TenantID = os.Getenv("AZURE_TENANT_ID")
-		c.SubscriptionID = os.Getenv("AZURE_SUBSCRIPTION_ID")
+	if err := envconfig.Process("config", c); err != nil {
+		return c, err
 	}
+
 	// validate parsed config
 	if err := validateConfig(c); err != nil {
 		return nil, err

--- a/pkg/webhook/consts.go
+++ b/pkg/webhook/consts.go
@@ -27,4 +27,6 @@ const (
 	AzureClientIDEnvVar = "AZURE_CLIENT_ID"
 	AzureTenantIDEnvVar = "AZURE_TENANT_ID"
 	TokenFilePathEnvVar = "TOKEN_FILE_PATH" // #nosec
+	TokenFilePathName   = "azure-identity-token"
+	TokenFileMountPath  = "/var/run/secrets/tokens" // #nosec
 )

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -345,13 +346,13 @@ func TestAddProjectedServiceAccountTokenVolume(t *testing.T) {
 			},
 			expectedVolume: []corev1.Volume{
 				{
-					Name: "azure-identity-token",
+					Name: TokenFilePathName,
 					VolumeSource: corev1.VolumeSource{
 						Projected: &corev1.ProjectedVolumeSource{
 							Sources: []corev1.VolumeProjection{
 								{
 									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-										Path:              "azure-identity-token",
+										Path:              TokenFilePathName,
 										ExpirationSeconds: &serviceAccountTokenExpiry,
 										Audience:          "https://login.microsoftonline.com/federatedidentity",
 									},
@@ -372,13 +373,13 @@ func TestAddProjectedServiceAccountTokenVolume(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "azure-identity-token",
+							Name: TokenFilePathName,
 							VolumeSource: corev1.VolumeSource{
 								Projected: &corev1.ProjectedVolumeSource{
 									Sources: []corev1.VolumeProjection{
 										{
 											ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-												Path:              "azure-identity-token",
+												Path:              TokenFilePathName,
 												ExpirationSeconds: &serviceAccountTokenExpiry,
 												Audience:          "https://login.microsoftonline.com/federatedidentity",
 											},
@@ -392,13 +393,13 @@ func TestAddProjectedServiceAccountTokenVolume(t *testing.T) {
 			},
 			expectedVolume: []corev1.Volume{
 				{
-					Name: "azure-identity-token",
+					Name: TokenFilePathName,
 					VolumeSource: corev1.VolumeSource{
 						Projected: &corev1.ProjectedVolumeSource{
 							Sources: []corev1.VolumeProjection{
 								{
 									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-										Path:              "azure-identity-token",
+										Path:              TokenFilePathName,
 										ExpirationSeconds: &serviceAccountTokenExpiry,
 										Audience:          "https://login.microsoftonline.com/federatedidentity",
 									},
@@ -419,7 +420,7 @@ func TestAddProjectedServiceAccountTokenVolume(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "azure-identity-token",
+							Name: TokenFilePathName,
 							VolumeSource: corev1.VolumeSource{
 								Projected: &corev1.ProjectedVolumeSource{
 									Sources: []corev1.VolumeProjection{
@@ -439,7 +440,7 @@ func TestAddProjectedServiceAccountTokenVolume(t *testing.T) {
 			},
 			expectedVolume: []corev1.Volume{
 				{
-					Name: "azure-identity-token",
+					Name: TokenFilePathName,
 					VolumeSource: corev1.VolumeSource{
 						Projected: &corev1.ProjectedVolumeSource{
 							Sources: []corev1.VolumeProjection{
@@ -455,13 +456,13 @@ func TestAddProjectedServiceAccountTokenVolume(t *testing.T) {
 					},
 				},
 				{
-					Name: "azure-identity-token",
+					Name: TokenFilePathName,
 					VolumeSource: corev1.VolumeSource{
 						Projected: &corev1.ProjectedVolumeSource{
 							Sources: []corev1.VolumeProjection{
 								{
 									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-										Path:              "azure-identity-token",
+										Path:              TokenFilePathName,
 										ExpirationSeconds: &serviceAccountTokenExpiry,
 										Audience:          "https://login.microsoftonline.com/federatedidentity",
 									},
@@ -513,7 +514,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 					},
 					{
 						Name:  "TOKEN_FILE_PATH",
-						Value: "/var/run/secrets/tokens/azure-identity-token",
+						Value: filepath.Join(TokenFileMountPath, TokenFilePathName),
 					},
 				},
 			},
@@ -534,7 +535,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 					},
 					{
 						Name:  "TOKEN_FILE_PATH",
-						Value: "/var/run/secrets/tokens/azure-identity-token",
+						Value: filepath.Join(TokenFileMountPath, TokenFilePathName),
 					},
 				},
 			},
@@ -552,7 +553,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 					},
 					{
 						Name:  "TOKEN_FILE_PATH",
-						Value: "/var/run/secrets/tokens/azure-identity-token",
+						Value: filepath.Join(TokenFileMountPath, TokenFilePathName),
 					},
 				},
 			},
@@ -587,7 +588,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 					},
 					{
 						Name:  "TOKEN_FILE_PATH",
-						Value: "/var/run/secrets/tokens/azure-identity-token",
+						Value: filepath.Join(TokenFileMountPath, TokenFilePathName),
 					},
 				},
 			},
@@ -621,7 +622,7 @@ func TestAddProjectServiceAccountTokenVolumeMount(t *testing.T) {
 				Image: "image",
 				VolumeMounts: []corev1.VolumeMount{
 					{
-						Name:      "azure-identity-token",
+						Name:      TokenFilePathName,
 						MountPath: "/var/run/secrets/tokens",
 						ReadOnly:  true,
 					},
@@ -635,7 +636,7 @@ func TestAddProjectServiceAccountTokenVolumeMount(t *testing.T) {
 				Image: "image",
 				VolumeMounts: []corev1.VolumeMount{
 					{
-						Name:      "azure-identity-token",
+						Name:      TokenFilePathName,
 						MountPath: "mountPath",
 					},
 				},
@@ -645,7 +646,7 @@ func TestAddProjectServiceAccountTokenVolumeMount(t *testing.T) {
 				Image: "image",
 				VolumeMounts: []corev1.VolumeMount{
 					{
-						Name:      "azure-identity-token",
+						Name:      TokenFilePathName,
 						MountPath: "mountPath",
 					},
 				},
@@ -672,7 +673,7 @@ func TestAddProjectServiceAccountTokenVolumeMount(t *testing.T) {
 						MountPath: "/var/run/pods",
 					},
 					{
-						Name:      "azure-identity-token",
+						Name:      TokenFilePathName,
 						MountPath: "/var/run/secrets/tokens",
 						ReadOnly:  true,
 					},
@@ -683,7 +684,7 @@ func TestAddProjectServiceAccountTokenVolumeMount(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualContainer := addProjectServiceAccountTokenVolumeMount(test.container)
+			actualContainer := addProjectedTokenVolumeMount(test.container)
 			if !reflect.DeepEqual(actualContainer, test.expectedContainer) {
 				t.Fatalf("expected: %v, got: %v", test.expectedContainer, actualContainer)
 			}
@@ -730,5 +731,199 @@ func TestHandle(t *testing.T) {
 	resp := m.Handle(context.Background(), req)
 	if !resp.Allowed {
 		t.Fatalf("expected to be allowed")
+	}
+}
+
+func TestAddProjectedSecretVolume(t *testing.T) {
+	tests := []struct {
+		name           string
+		pod            *corev1.Pod
+		expectedVolume []corev1.Volume
+	}{
+		{
+			name: "no volumes in the pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+			},
+			expectedVolume: []corev1.Volume{
+				{
+					Name: TokenFilePathName,
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									Secret: &corev1.SecretProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "localtoken-sa",
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "token",
+												Path: TokenFilePathName,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "azure-identity-token projected volume already exists",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: TokenFilePathName,
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									Sources: []corev1.VolumeProjection{
+										{
+											Secret: &corev1.SecretProjection{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: "localtoken-sa",
+												},
+												Items: []corev1.KeyToPath{
+													{
+														Key:  "token",
+														Path: TokenFilePathName,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedVolume: []corev1.Volume{
+				{
+					Name: TokenFilePathName,
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									Secret: &corev1.SecretProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "localtoken-sa",
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "token",
+												Path: TokenFilePathName,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "existing projected secret volume not affected",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: TokenFilePathName,
+							VolumeSource: corev1.VolumeSource{
+								Projected: &corev1.ProjectedVolumeSource{
+									Sources: []corev1.VolumeProjection{
+										{
+											Secret: &corev1.SecretProjection{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: "my-secret",
+												},
+												Items: []corev1.KeyToPath{
+													{
+														Key:  "username",
+														Path: "username",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedVolume: []corev1.Volume{
+				{
+					Name: TokenFilePathName,
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									Secret: &corev1.SecretProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "my-secret",
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "username",
+												Path: "username",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: TokenFilePathName,
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									Secret: &corev1.SecretProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "localtoken-sa",
+										},
+										Items: []corev1.KeyToPath{
+											{
+												Key:  "token",
+												Path: TokenFilePathName,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := addProjectedSecretVolume(test.pod, &config.Config{}, "localtoken-sa")
+			if err != nil {
+				t.Fatalf("expected err to be nil, got: %v", err)
+			}
+			if !reflect.DeepEqual(test.pod.Spec.Volumes, test.expectedVolume) {
+				t.Fatalf("expected: %v, got: %v", test.pod.Spec.Volumes, test.expectedVolume)
+			}
+		})
 	}
 }

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -65,6 +65,11 @@ create_cluster_and_deploy() {
     export IMG
     make container-manager
   fi
+
+  # create the webhook namespace
+  ${KUBECTL} create namespace aad-pi-webhook-system
+  # create the configmap that'll be used for the webhook
+  ${KUBECTL} create configmap aad-pi-config --from-literal=AZURE_TENANT_ID="${AZURE_TENANT_ID}" --from-literal=AZURE_ENVIRONMENT="${AZURE_ENVIRONMENT:-AzurePublicCloud}" --namespace=aad-pi-webhook-system
 }
 
 cleanup() {

--- a/scripts/create-kind-cluster.sh
+++ b/scripts/create-kind-cluster.sh
@@ -8,30 +8,17 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${REPO_ROOT}" || exit 1
 
 : "${AZURE_TENANT_ID:?Environment variable empty or not defined.}"
-: "${AZURE_SUBSCRIPTION_ID:?Environment variable empty or not defined.}"
 
 readonly KIND="${REPO_ROOT}/hack/tools/bin/kind"
 readonly KUBECTL="${REPO_ROOT}/hack/tools/bin/kubectl"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-aad-pod-managed-identity}"
 
-# create a fake azure.json based on environment variables
-cat <<EOF > "${REPO_ROOT}/azure.json"
-{
-  "cloud": "${AZURE_ENVIRONMENT:-AzurePublicCloud}",
-  "tenantId": "${AZURE_TENANT_ID}",
-  "subscriptionId": "${AZURE_SUBSCRIPTION_ID}"
-}
-EOF
-
-# create a kind cluster with azure.json mounted
+# create a kind cluster
 cat <<EOF | ${KIND} create cluster --name "${KIND_CLUSTER_NAME}" --image "kindest/node:${KIND_NODE_VERSION:-v1.20.2}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  extraMounts:
-  - hostPath: ${REPO_ROOT}/azure.json
-    containerPath: /etc/kubernetes/azure.json
 EOF
 
 ${KUBECTL} wait node "${KIND_CLUSTER_NAME}-control-plane" --for=condition=Ready --timeout=90s

--- a/test/e2e/webhook/webhook.go
+++ b/test/e2e/webhook/webhook.go
@@ -98,8 +98,8 @@ func validateMutatedPod(pod *corev1.Pod) {
 			if volumeMount.Name == "azure-identity-token" {
 				found = true
 				gomega.Expect(volumeMount).To(gomega.Equal(corev1.VolumeMount{
-					Name:      "azure-identity-token",
-					MountPath: "/var/run/secrets/tokens",
+					Name:      webhook.TokenFilePathName,
+					MountPath: webhook.TokenFileMountPath,
 					ReadOnly:  true,
 				}))
 				break
@@ -115,16 +115,16 @@ func validateMutatedPod(pod *corev1.Pod) {
 	defaultMode := int32(420)
 	found := false
 	for _, volume := range pod.Spec.Volumes {
-		if volume.Name == "azure-identity-token" {
+		if volume.Name == webhook.TokenFilePathName {
 			found = true
 			gomega.Expect(volume).To(gomega.Equal(corev1.Volume{
-				Name: "azure-identity-token",
+				Name: webhook.TokenFilePathName,
 				VolumeSource: corev1.VolumeSource{
 					Projected: &corev1.ProjectedVolumeSource{
 						Sources: []corev1.VolumeProjection{
 							{
 								ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-									Path:              "azure-identity-token",
+									Path:              webhook.TokenFilePathName,
 									ExpirationSeconds: &expirationSeconds,
 									Audience:          fmt.Sprintf("%s/federatedidentity", strings.TrimRight(azure.PublicCloud.ActiveDirectoryEndpoint, "/")),
 								},


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Added a new flag `--arc-cluster` which can be used for configuring webhook in arc clusters.
- Removed dependency on `azure.json`, so it's easier to deploy and run the webhook on any non-azure cluster.

The config is obtained from a configmap
```bash
kubectl create configmap aad-pi-config --from-literal=AZURE_TENANT_ID=${AZURE_TENANT_ID} --namespace=aad-pi-webhook-system
```

fixes #16 