### PR TITLE
test: add an e2e job for windows containerd cluster

### DIFF
--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -51,9 +51,13 @@ jobs:
       AZURE_TENANT_ID: "fake tenant id"
     strategy:
       matrix:
-        aks_windows:
+        aks_windows_dockershim:
           REGISTRY: upstreamk8sci.azurecr.io/aad-pod-managed-identity
           WINDOWS_CLUSTER: "true"
+        aks_windows_containerd:
+          REGISTRY: upstreamk8sci.azurecr.io/aad-pod-managed-identity
+          WINDOWS_CLUSTER: "true"
+          WINDOWS_CONTAINERD: "true"
         aks_linux:
           REGISTRY: upstreamk8sci.azurecr.io/aad-pod-managed-identity
         arc:

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -12,21 +12,6 @@ readonly KUBECTL="${REPO_ROOT}/hack/tools/bin/kubectl"
 IMAGE_VERSION="$(git rev-parse --short HEAD)"
 export IMAGE_VERSION
 
-get_random_region() {
-    local REGIONS=("eastus" "eastus2" "westus2" "westeurope" "uksouth" "northeurope" "francecentral")
-    echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
-}
-
-should_create_aks_cluster() {
-  if [[ "${SOAK_CLUSTER:-}" == "true" ]] || [[ -n "${KUBECONFIG:-}" ]]; then
-    echo "false" && return
-  fi
-  if az aks show --resource-group "${CLUSTER_NAME}" --name "${CLUSTER_NAME}" > /dev/null; then
-    echo "false" && return
-  fi
-  echo "true" && return
-}
-
 create_cluster() {
   if [[ "${LOCAL_ONLY:-}" == "true" ]]; then
     # create a kind cluster, then build and load the webhook manager image to the cluster
@@ -37,27 +22,7 @@ create_cluster() {
     az login -i > /dev/null && echo "Using machine identity for az commands" || echo "Using pre-existing credential for az commands"
 
     CLUSTER_NAME="${CLUSTER_NAME:-pod-managed-identity-e2e-$(openssl rand -hex 2)}"
-    if [[ "$(should_create_aks_cluster)" == "true" ]]; then
-      echo "Creating an AKS cluster '${CLUSTER_NAME}'"
-      az group create --name "${CLUSTER_NAME}" --location "$(get_random_region)" > /dev/null
-      # TODO(chewong): ability to create an arc-enabled cluster
-      az aks create \
-        --resource-group "${CLUSTER_NAME}" \
-        --name "${CLUSTER_NAME}" \
-        --node-vm-size Standard_DS3_v2 \
-        --enable-managed-identity \
-        --network-plugin azure \
-        --node-count 1 \
-        --generate-ssh-keys > /dev/null
-      if [[ "${WINDOWS_CLUSTER:-}" == "true" ]]; then
-        az aks nodepool add \
-          --resource-group "${CLUSTER_NAME}" \
-          --cluster-name "${CLUSTER_NAME}" \
-          --os-type Windows \
-          --name npwin \
-          --node-count 1 > /dev/null
-      fi
-    fi
+    "${REPO_ROOT}/scripts/create-aks-cluster.sh"
 
     # assume BYO cluster if KUBECONFIG is defined
     if [[ -z "${KUBECONFIG:-}" ]]; then
@@ -101,16 +66,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
-create_cluster
-${KUBECTL} get nodes -owide
+main() {
+  create_cluster
+  ${KUBECTL} get nodes -owide
 
-make clean deploy
+  make clean deploy
 
-if [[ -n "${WINDOWS_NODE_NAME:-}" ]]; then
-  # remove the taint from the windows node we introduced above
-  ${KUBECTL} taint nodes "${WINDOWS_NODE_NAME}" kubernetes.io/os=windows:NoSchedule-
-  E2E_ARGS="--node-os-distro=windows ${E2E_ARGS:-}"
-  export E2E_ARGS
-fi
+  if [[ -n "${WINDOWS_NODE_NAME:-}" ]]; then
+    # remove the taint from the windows node we introduced above
+    ${KUBECTL} taint nodes "${WINDOWS_NODE_NAME}" kubernetes.io/os=windows:NoSchedule-
+    E2E_ARGS="--node-os-distro=windows ${E2E_ARGS:-}"
+    export E2E_ARGS
+  fi
 
-make test-e2e-run
+  make test-e2e-run
+}
+
+main

--- a/scripts/create-aks-cluster.sh
+++ b/scripts/create-aks-cluster.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${CLUSTER_NAME:?Environment variable empty or not defined.}"
+
+get_random_region() {
+    local REGIONS=("eastus" "eastus2" "westus2" "westeurope" "uksouth" "northeurope" "francecentral")
+    echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
+}
+
+should_create_aks_cluster() {
+  if [[ "${SOAK_CLUSTER:-}" == "true" ]] || [[ -n "${KUBECONFIG:-}" ]]; then
+    echo "false" && return
+  fi
+  if az aks show --resource-group "${CLUSTER_NAME}" --name "${CLUSTER_NAME}" > /dev/null; then
+    echo "false" && return
+  fi
+  echo "true" && return
+}
+
+register_feature() {
+  # https://docs.microsoft.com/en-us/azure/aks/windows-container-cli#add-a-windows-server-node-pool-with-containerd-preview
+  az extension add --name aks-preview
+  az extension update --name aks-preview
+  az feature register --namespace Microsoft.ContainerService --name UseCustomizedWindowsContainerRuntime > /dev/null
+  while [[ "$(az feature list --query "[?contains(name, 'Microsoft.ContainerService/UseCustomizedWindowsContainerRuntime')].{Name:name,State:properties.state}" | jq -r '.[].State')" != "Registered" ]]; do
+    sleep 20
+  done
+  az provider register --namespace Microsoft.ContainerService
+}
+
+main() {
+  if [[ "$(should_create_aks_cluster)" == "true" ]]; then
+    echo "Creating an AKS cluster '${CLUSTER_NAME}'"
+    az group create --name "${CLUSTER_NAME}" --location "$(get_random_region)" > /dev/null
+    # TODO(chewong): ability to create an arc-enabled cluster
+    az aks create \
+      --resource-group "${CLUSTER_NAME}" \
+      --name "${CLUSTER_NAME}" \
+      --node-vm-size Standard_DS3_v2 \
+      --enable-managed-identity \
+      --network-plugin azure \
+      --kubernetes-version 1.20.5 \
+      --node-count 1 \
+      --generate-ssh-keys > /dev/null
+    if [[ "${WINDOWS_CLUSTER:-}" == "true" ]]; then
+      if [[ "${WINDOWS_CONTAINERD:-}" == "true" ]]; then
+        export -f register_feature
+        # might take around 20 minutes to register
+        timeout --foreground 1200 bash -c register_feature
+        EXTRA_ARGS="--aks-custom-headers WindowsContainerRuntime=containerd"
+      fi
+      # shellcheck disable=SC2086
+      az aks nodepool add --resource-group "${CLUSTER_NAME}" --cluster-name "${CLUSTER_NAME}" --os-type Windows --name npwin --kubernetes-version 1.20.5 --node-count 1 ${EXTRA_ARGS:-} > /dev/null
+    fi
+  fi
+}
+
+main


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

ref #9

Running e2e against a windows node with containerd as the container runtime on AKS:
```
NAME                                STATUS   ROLES   AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION     CONTAINER-RUNTIME
aks-nodepool1-18895737-vmss000000   Ready    agent   11m     v1.20.5   10.240.0.4    <none>        Ubuntu 18.04.5 LTS               5.4.0-1046-azure   containerd://1.4.4+azure
aksnpwin000000                      Ready    agent   3m10s   v1.20.5   10.240.0.35   <none>        Windows Server 2019 Datacenter   10.0.17763.1935    containerd://1.4.4+unknown
```