### PR TITLE
test: setup nightly test pipeline

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -1,0 +1,47 @@
+trigger: none
+
+schedules:
+  - cron: "0 0 * * *"
+    always: true
+    displayName: "Nightly Test"
+    branches:
+      include:
+        - main
+
+pool: Upstream Pool
+
+jobs:
+  - job: scan_images
+    timeoutInMinutes: 10
+    workspace:
+      clean: all
+    steps:
+      - template: templates/publish-images.yaml
+        parameters:
+          publish: false
+  - job:
+    timeoutInMinutes: 40
+    dependsOn: scan_images
+    workspace:
+      clean: all
+    variables:
+      # we can enable actual tenant id for functional e2e
+      AZURE_TENANT_ID: "fake tenant id"
+      REGISTRY: upstreamk8sci.azurecr.io/aad-pod-managed-identity
+      SOAK_CLUSTER: "true"
+    strategy:
+      matrix:
+        soak_aks_windows_dockershim:
+          WINDOWS_CLUSTER: "true"
+          CLUSTER_NAME: "pmi-aks-win-dockershim"
+        soak_aks_windows_containerd:
+          WINDOWS_CLUSTER: "true"
+          CLUSTER_NAME: "pmi-aks-win-containerd"
+        soak_aks_linux:
+          CLUSTER_NAME: "pmi-aks-linux"
+        soak_arc:
+          ARC_CLUSTER: "true"
+          CLUSTER_NAME: "pmi-aks-arc"
+    steps:
+      - script: make test-e2e
+        displayName: Webhook E2E test suite


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Created 4 clusters with the following configurations in the CI subscription for soaking purposes:

- Linux
- Windows with dockershim
- Windows with containerd
- (fake) arc cluster

Test result: https://dev.azure.com/AzureContainerUpstream/AAD%20Pod%20Managed%20Identity/_build/results?buildId=21438&view=results

ref: #9