### PR TITLE
test: add upgrade test as part of nightly pipeline

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -20,7 +20,7 @@ jobs:
         parameters:
           publish: false
   - job:
-    timeoutInMinutes: 40
+    timeoutInMinutes: 20
     dependsOn: scan_images
     workspace:
       clean: all
@@ -45,3 +45,43 @@ jobs:
     steps:
       - script: make test-e2e
         displayName: Webhook E2E test suite
+  - job:
+    timeoutInMinutes: 60
+    dependsOn: scan_images
+    workspace:
+      clean: all
+    variables:
+      # we can enable actual tenant id for functional e2e
+      AZURE_TENANT_ID: "fake tenant id"
+      REGISTRY: upstreamk8sci.azurecr.io/aad-pod-managed-identity
+    strategy:
+      matrix:
+        upgrade_aks_windows_dockershim:
+          WINDOWS_CLUSTER: "true"
+        upgrade_aks_windows_containerd:
+          WINDOWS_CLUSTER: "true"
+          WINDOWS_CONTAINERD: "true"
+        upgrade_aks_linux:
+          DUMMY_VAR: ""
+        upgrade_arc:
+          ARC_CLUSTER: "true"
+    steps:
+      - script: echo "##vso[task.setvariable variable=CLUSTER_NAME]pod-managed-identity-e2e-$(openssl rand -hex 2)"
+        displayName: Set CLUSTER_NAME
+      - script: make test-e2e
+        displayName: Webhook E2E test suite
+        env:
+          SKIP_CLEANUP: "true"
+      - script: |
+          KUBECTL="$(pwd)/hack/tools/bin/kubectl"
+          WINDOWS_NODE_NAME="$(${KUBECTL} get node --selector=kubernetes.io/os=windows -ojson | jq -r '.items[0].metadata.name')"
+          ${KUBECTL} taint nodes "${WINDOWS_NODE_NAME}" kubernetes.io/os=windows:NoSchedule --overwrite
+        displayName: Taint Windows nodes before upgrade
+        condition: and(succeeded(), eq(variables.WINDOWS_CLUSTER, 'true'))
+      - script: az aks upgrade --resource-group "${CLUSTER_NAME}" --name "${CLUSTER_NAME}" --kubernetes-version 1.21.1 --yes > /dev/null
+        displayName: Upgrade cluster
+      - script: make test-e2e
+        displayName: Webhook E2E test suite
+      - script: az group delete --name "${CLUSTER_NAME}" --yes --no-wait || true
+        displayName: Cleanup
+        condition: always()

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -35,7 +35,7 @@ create_cluster() {
       unset WINDOWS_NODE_NAME
     else
       # taint the windows node to prevent cert-manager pods from scheduling to it
-      ${KUBECTL} taint nodes "${WINDOWS_NODE_NAME}" kubernetes.io/os=windows:NoSchedule
+      ${KUBECTL} taint nodes "${WINDOWS_NODE_NAME}" kubernetes.io/os=windows:NoSchedule --overwrite
     fi
 
     if [[ "${REGISTRY}" =~ \.azurecr\.io ]]; then


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Added cluster upgrade scenarios from v1.20.5 to v1.21.1 with the following cluster configurations:

- Linux
- Windows with dockershim
- Windows with containerd
- (fake) arc cluster

Test result: https://dev.azure.com/AzureContainerUpstream/AAD%20Pod%20Managed%20Identity/_build/results?buildId=21487&view=results

ref #9