### PR TITLE
chore: ensure availability after installing cert-manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,14 +180,12 @@ $(ENVSUBST):
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/a8m/envsubst/cmd/envsubst $(ENVSUBST_BIN) $(ENVSUBST_VER)
 
 CERT_MANAGER_VERSION ?= v1.2.0
+export CERT_MANAGER_VERSION
 
 # Install cert manager in the cluster
 .PHONY: install-cert-manager
 install-cert-manager: $(KUBECTL)
-	$(KUBECTL) apply -f https://github.com/jetstack/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
-	$(KUBECTL) wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
-	$(KUBECTL) wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
-	$(KUBECTL) wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook
+	./hack/install-cert-manager.sh
 
 ## --------------------------------------
 ## Testing

--- a/hack/install-cert-manager.sh
+++ b/hack/install-cert-manager.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${CERT_MANAGER_VERSION:?Environment variable empty or not defined.}"
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}" || exit 1
+
+readonly KUBECTL="${REPO_ROOT}/hack/tools/bin/kubectl"
+
+TEST_RESOURCE=$(cat <<-END
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-test
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: test-selfsigned
+  namespace: cert-manager-test
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: selfsigned-cert
+  namespace: cert-manager-test
+spec:
+  dnsNames:
+    - example.com
+  secretName: selfsigned-cert-tls
+  issuerRef:
+    name: test-selfsigned
+END
+)
+
+## Install cert manager and wait for availability
+${KUBECTL} apply -f "https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+${KUBECTL} wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager
+${KUBECTL} wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-cainjector
+${KUBECTL} wait --for=condition=Available --timeout=5m -n cert-manager deployment/cert-manager-webhook
+
+for _ in {1..6}; do
+  if echo "${TEST_RESOURCE}" | kubectl apply -f -; then
+    break
+  fi
+  sleep 15
+done
+
+${KUBECTL} wait --for=condition=Ready --timeout=5m -n cert-manager-test certificate/selfsigned-cert
+
+trap 'echo "${TEST_RESOURCE}" | kubectl delete -f -' EXIT


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Ensure availability after installing cert-manager by installing a dummy `Certificate` and checking if it's ready.

xref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/hack/install-cert-manager.sh

Fixes:
- https://github.com/Azure/aad-pod-managed-identity/pull/24#discussion_r630580900
- https://dev.azure.com/AzureContainerUpstream/AAD%20Pod%20Managed%20Identity/_build/results?buildId=21959&view=logs&j=64513240-c852-5bba-79dd-3142076aa2ff&t=e582798b-c381-583f-5283-a02a4cd08152