### PR TITLE
feat: add readiness and liveness probes to webhook

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -19,6 +20,7 @@ var (
 	audience       string
 	webhookCertDir string
 	tlsMinVersion  string
+	healthAddr     string
 )
 
 func init() {
@@ -35,6 +37,7 @@ func main() {
 	// ref: https://github.com/kubernetes-sigs/controller-runtime/issues/900
 	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "", "Webhook certificates dir to use. Defaults to {TempDir}/k8s-webhook-server/serving-certs")
 	flag.StringVar(&tlsMinVersion, "tls-min-version", "1.3", "Minimum TLS version")
+	flag.StringVar(&healthAddr, "health-addr", ":9440", "The address the health endpoint binds to")
 	flag.Parse()
 
 	entryLog := log.Log.WithName("entrypoint")
@@ -42,7 +45,8 @@ func main() {
 	// Setup a manager
 	entryLog.Info("setting up manager")
 	mgrOpts := manager.Options{
-		CertDir: webhookCertDir,
+		CertDir:                webhookCertDir,
+		HealthProbeBindAddress: healthAddr,
 	}
 	mgr, err := manager.New(config.GetConfigOrDie(), mgrOpts)
 	if err != nil {
@@ -62,6 +66,16 @@ func main() {
 		os.Exit(1)
 	}
 	hookServer.Register("/mutate-v1-pod", &webhook.Admission{Handler: podMutator})
+
+	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
+		entryLog.Error(err, "unable to create ready check")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+		entryLog.Error(err, "unable to create health check")
+		os.Exit(1)
+	}
 
 	entryLog.Info("starting manager")
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,6 +26,18 @@ spec:
         image: manager:latest
         imagePullPolicy: IfNotPresent
         name: manager
+        ports:
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
         resources:
           limits:
             cpu: 100m

--- a/manifest_staging/charts/pod-identity-webhook/templates/aad-pi-webhook-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/pod-identity-webhook/templates/aad-pi-webhook-controller-manager-deployment.yaml
@@ -34,11 +34,22 @@ spec:
             name: aad-pi-webhook-config
         image: '{{ .Values.image.repository }}:{{ .Values.image.release }}'
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
         name: manager
         ports:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         volumeMounts:

--- a/manifest_staging/deploy/aad-pi-webhook.yaml
+++ b/manifest_staging/deploy/aad-pi-webhook.yaml
@@ -92,11 +92,22 @@ spec:
             name: aad-pi-webhook-config
         image: mcr.microsoft.com/oss/azure/aad-pod-managed-identity/webhook:v0.2.0
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
         name: manager
         ports:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
         resources:
           limits:
             cpu: 100m

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -110,8 +110,6 @@ test_helm_chart() {
       --set azureTenantID="${AZURE_TENANT_ID}" \
       --namespace aad-pi-webhook-system \
       --wait
-    # TODO: remove this once we have a readiness probe in place
-    sleep 60
     make test-e2e-run
   fi
 
@@ -122,8 +120,6 @@ test_helm_chart() {
     --namespace aad-pi-webhook-system \
     --reuse-values \
     --wait
-  # TODO: remove this once we have a readiness probe in place
-  sleep 60
   make test-e2e-run
 }
 


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Managed Identity? Why is it needed? -->

Implement liveness and readiness probe for the webhook.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-managed-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in AAD Pod Managed Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/aad-pod-managed-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #94 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
