### PR TITLE
ci: collect pod logs after e2e test suite is finished running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ sa.pub
 
 # book
 docs/book/book/
+
+# logs
+_artifacts/

--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -83,6 +83,7 @@ jobs:
     steps:
       - script: make test-e2e
         displayName: Webhook E2E test suite
+      - template: templates/publish-logs.yaml
   - job:
     timeoutInMinutes: 60
     dependsOn:
@@ -126,6 +127,7 @@ jobs:
       - script: az group delete --name "${CLUSTER_NAME}" --yes --no-wait || true
         displayName: Cleanup
         condition: always()
+      - template: templates/publish-logs.yaml
   - job:
     timeoutInMinutes: 40
     dependsOn:
@@ -164,3 +166,4 @@ jobs:
           SERVICE_ACCOUNT_ISSUER: $(SERVICE_ACCOUNT_ISSUER)
           SERVICE_ACCOUNT_KEYVAULT_NAME: $(SERVICE_ACCOUNT_KEYVAULT_NAME)
           SERVICE_PRINCIPAL_CLIENT_ID: $(SERVICE_PRINCIPAL_CLIENT_ID)
+      - template: templates/publish-logs.yaml

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -109,3 +109,4 @@ jobs:
       - script: az group delete --name "${CLUSTER_NAME}" --yes --no-wait || true
         displayName: Cleanup
         condition: ne(variables.LOCAL_ONLY, 'true')
+      - template: templates/publish-logs.yaml

--- a/.pipelines/templates/publish-logs.yaml
+++ b/.pipelines/templates/publish-logs.yaml
@@ -1,0 +1,18 @@
+parameters:
+  - name: log_path
+    type: string
+    default: _artifacts
+
+steps:
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      testResultsFiles: "_artifacts/**/junit*.xml"
+    displayName: Publish test results
+    condition: always()
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: ${{ parameters.log_path }}
+      artifactName: artifacts/$(Agent.JobName)
+    displayName: Publish logs
+    condition: always()

--- a/Makefile
+++ b/Makefile
@@ -247,18 +247,19 @@ $(E2E_TEST):
 # Ginkgo configurations
 GINKGO_FOCUS ?=
 GINKGO_SKIP ?=
-GINKGO_NODES ?= 5
+GINKGO_NODES ?= 3
 GINKGO_NO_COLOR ?= false
 GINKGO_ARGS ?= -focus="$(GINKGO_FOCUS)" -skip="$(GINKGO_SKIP)" -nodes=$(GINKGO_NODES) -noColor=$(GINKGO_NO_COLOR)
 
 # E2E configurations
-E2E_ARGS ?=
 KUBECONFIG ?= $(HOME)/.kube/config
+E2E_ARGS := -kubeconfig=$(KUBECONFIG) -report-dir=$(PWD)/_artifacts -e2e.arc-cluster=$(ARC_CLUSTER)
+E2E_EXTRA_ARGS ?=
 
 .PHONY: test-e2e-run
 test-e2e-run: $(E2E_TEST) $(GINKGO)
 	$(GINKGO) -v -trace $(GINKGO_ARGS) \
-		$(E2E_TEST) -- -kubeconfig=$(KUBECONFIG) -e2e.arc-cluster=$(ARC_CLUSTER) $(E2E_ARGS)
+		$(E2E_TEST) -- $(E2E_ARGS) $(E2E_EXTRA_ARGS)
 
 .PHONY: test-e2e
 test-e2e: $(KUBECTL) $(HELM)


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Managed Identity? Why is it needed? -->

Fixes #98. This PR will collect pod logs in `ginkgo.SynchronizedBeforeSuite` and store them in `${REPO_ROOT}/_artifacts`. They will be uploaded as artifacts to ADO.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-managed-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in AAD Pod Managed Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/aad-pod-managed-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
