### PR TITLE
e2e: remove `make install-cert-manager` for verify_deployment

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -39,8 +39,6 @@ jobs:
         env:
           SKIP_PREFLIGHT: "true"
           SERVICE_ACCOUNT_ISSUER: $(SERVICE_ACCOUNT_ISSUER)
-      - script: make install-cert-manager
-        displayName: Installing cert-manager
       - script: |
           sed -i "s/AZURE_TENANT_ID: .*/AZURE_TENANT_ID: ${AZURE_TENANT_ID}/" manifest_staging/deploy/aad-pi-webhook.yaml
           sed -i "s/AZURE_ENVIRONMENT: .*/AZURE_ENVIRONMENT: AzurePublicCloud/" manifest_staging/deploy/aad-pi-webhook.yaml

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -36,9 +36,6 @@ create_cluster() {
     WINDOWS_NODE_NAME="$(${KUBECTL} get node --selector=kubernetes.io/os=windows -ojson | jq -r '.items[0].metadata.name')"
     if [[ "${WINDOWS_NODE_NAME}" == "null" ]]; then
       unset WINDOWS_NODE_NAME
-    else
-      # taint the windows node to prevent cert-manager pods from scheduling to it
-      ${KUBECTL} taint nodes "${WINDOWS_NODE_NAME}" kubernetes.io/os=windows:NoSchedule --overwrite
     fi
 
     if [[ "${REGISTRY}" =~ \.azurecr\.io ]]; then
@@ -88,8 +85,6 @@ main() {
   sleep 120
 
   if [[ -n "${WINDOWS_NODE_NAME:-}" ]]; then
-    # remove the taint from the windows node we introduced above
-    ${KUBECTL} taint nodes "${WINDOWS_NODE_NAME}" kubernetes.io/os=windows:NoSchedule-
     E2E_ARGS="--node-os-distro=windows ${E2E_ARGS:-}"
     export E2E_ARGS
   fi


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Managed Identity? Why is it needed? -->
- Removes `make install-cert-manager` from verify_deployment.
- Removes the windows node taint that was required when using cert-manager

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-managed-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in AAD Pod Managed Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/aad-pod-managed-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
