### PR TITLE
fix: do not taint windows nodes before upgrading the cluster

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -112,12 +112,6 @@ jobs:
         displayName: Webhook E2E test suite
         env:
           SKIP_CLEANUP: "true"
-      - script: |
-          KUBECTL="$(pwd)/hack/tools/bin/kubectl"
-          WINDOWS_NODE_NAME="$(${KUBECTL} get node --selector=kubernetes.io/os=windows -ojson | jq -r '.items[0].metadata.name')"
-          ${KUBECTL} taint nodes "${WINDOWS_NODE_NAME}" kubernetes.io/os=windows:NoSchedule --overwrite
-        displayName: Taint Windows nodes before upgrade
-        condition: and(succeeded(), eq(variables.WINDOWS_CLUSTER, 'true'))
       - script: az aks upgrade --resource-group "${CLUSTER_NAME}" --name "${CLUSTER_NAME}" --kubernetes-version 1.21.1 --yes > /dev/null
         displayName: Upgrade cluster
       - script: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,8 @@ GINKGO_FOCUS ?=
 GINKGO_SKIP ?=
 GINKGO_NODES ?= 3
 GINKGO_NO_COLOR ?= false
-GINKGO_ARGS ?= -focus="$(GINKGO_FOCUS)" -skip="$(GINKGO_SKIP)" -nodes=$(GINKGO_NODES) -noColor=$(GINKGO_NO_COLOR)
+GINKGO_TIMEOUT ?= 5m
+GINKGO_ARGS ?= -focus="$(GINKGO_FOCUS)" -skip="$(GINKGO_SKIP)" -nodes=$(GINKGO_NODES) -noColor=$(GINKGO_NO_COLOR) -timeout=$(GINKGO_TIMEOUT)
 
 # E2E configurations
 KUBECONFIG ?= $(HOME)/.kube/config


### PR DESCRIPTION
<s>Partially reverts Azure/aad-pod-managed-identity#102 to fix test failures in https://dev.azure.com/AzureContainerUpstream/AAD%20Pod%20Managed%20Identity/_build?definitionId=333. We need to taint the Windows node to prevent the webhook controller from scheduling to it.</s>

Realized that there is a step in nightly.yaml where the Windows node is tainted and since the untaint statement was removed in #102, we weren't able to schedule any Windows workload to it without any tolerations.
