### PR TITLE
docs: add tenant id reference in quick start

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -258,8 +258,7 @@ az keyvault secret set --vault-name ${KEYVAULT_NAME} \
 ## 6. Create a service principal and grant permissions to access the secret
 
 ```bash
-az ad sp create-for-rbac --skip-assignment --name https://test-sp
-export SERVICE_PRINCIPAL_CLIENT_ID="$(az ad sp show --id https://test-sp --query appId -otsv)"
+export SERVICE_PRINCIPAL_CLIENT_ID="$(az ad sp create-for-rbac --skip-assignment --name https://test-sp --query appId -otsv)"
 ```
 
 Set access policy for the service principal to access the keyvault secret:
@@ -301,6 +300,12 @@ serviceaccount/pod-identity-sa created
 ```
 
 </details>
+
+If the service principal is not in the same tenant as the Kubernetes cluster, then annotate the service account with the tenant id of the service principal.
+
+```bash
+kubectl annotate sa pod-identity-sa azure.pod.identity/tenant-id=${TENANT_ID} --overwrite
+```
 
 ## 9. Deploy workload
 
@@ -349,22 +354,22 @@ kubectl describe pod quick-start
 You can verifiy the following injected properties in the output:
 
 | Environment variable   | Description                                           |
-|------------------------|-------------------------------------------------------|
+| ---------------------- | ----------------------------------------------------- |
 | `AZURE_AUTHORITY_HOST` | The Azure Active Directory (AAD) endpoint.            |
 | `AZURE_CLIENT_ID`      | The client ID of the identity.                        |
 | `AZURE_TENANT_ID`      | The tenant ID of the Azure account.                   |
-| `TOKEN_FILE_PATH`      | The path of the projected service account token file.  |
+| `TOKEN_FILE_PATH`      | The path of the projected service account token file. |
 
 <br/>
 
-| Volume mount                                   | Description                                             |
-|------------------------------------------------|---------------------------------------------------------|
-| `/var/run/secrets/tokens/azure-identity-token` | The path of the projected service account token file.    |
+| Volume mount                                   | Description                                           |
+| ---------------------------------------------- | ----------------------------------------------------- |
+| `/var/run/secrets/tokens/azure-identity-token` | The path of the projected service account token file. |
 
 <br/>
 
 | Volume                 | Description                           |
-|------------------------|---------------------------------------|
+| ---------------------- | ------------------------------------- |
 | `azure-identity-token` | The projected service account volume. |
 
 ```log

--- a/examples/msal-net/akvdotnet/README.md
+++ b/examples/msal-net/akvdotnet/README.md
@@ -15,6 +15,8 @@ export RESOURCE_GROUP="<AKV resource group or existing resource group>"
 export LOCATION="<location>"
 export KEYVAULT_NAME="<key vault name>"
 export KEYVAULT_SECRET_NAME="<key vault secret name>"
+# this is only required if the keyvault instance is not in the same tenant as the cluster
+export TENANT_ID="<tenant id for the key vault instance>"
 ```
 
 **Prerequisites**
@@ -38,8 +40,7 @@ az keyvault secret set --vault-name ${KEYVAULT_NAME} --name ${KEYVAULT_SECRET_NA
 
 ```bash
 # create service principal
-az ad sp create-for-rbac --skip-assignment --name https://test-sp
-export SERVICE_PRINCIPAL_CLIENT_ID=$(az ad sp show --id https://test-sp --query appId -o tsv)
+export SERVICE_PRINCIPAL_CLIENT_ID=$(az ad sp create-for-rbac --skip-assignment --name https://test-sp --query appId -o tsv)
 
 # set policy to access keyvault secrets
 az keyvault set-policy -n ${KEYVAULT_NAME} --secret-permissions get --spn ${SERVICE_PRINCIPAL_CLIENT_ID}
@@ -63,6 +64,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    azure.pod.identity/tenant-id: ${TENANT_ID}
     azure.pod.identity/client-id: ${SERVICE_PRINCIPAL_CLIENT_ID}
   labels:
     azure.pod.identity/use: "true"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Managed Identity? Why is it needed? -->
- Updates the export SERVICE_PRINCIPAL_CLIENT_ID to use the output from `az ad sp create`.
- Adds reference to tenant id annotation if the keyvault instance and SP are in different tenant.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-managed-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in AAD Pod Managed Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/aad-pod-managed-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
