### PR TITLE
test: re-enable helm upgrade e2e

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -102,16 +102,15 @@ test_helm_chart() {
   ${KUBECTL} create namespace aad-pi-webhook-system
 
   # test helm upgrade from chart to manifest_staging/chart
-  # TODO (aramase) re-enable this when the release is complete and v0.3.0 image is available
-  # if [[ -d "${REPO_ROOT}/charts/pod-identity-webhook" ]]; then
-  #   ${HELM} install pod-identity-webhook "${REPO_ROOT}/charts/pod-identity-webhook" \
-  #     --set azureTenantID="${AZURE_TENANT_ID}" \
-  #     --namespace aad-pi-webhook-system \
-  #     --wait
-  #   # adding a sleep here because the cert mount is not ready immediately after the deploy
-  #   sleep 120
-  #   make test-e2e-run
-  # fi
+  if [[ -d "${REPO_ROOT}/charts/pod-identity-webhook" ]]; then
+    ${HELM} install pod-identity-webhook "${REPO_ROOT}/charts/pod-identity-webhook" \
+      --set azureTenantID="${AZURE_TENANT_ID}" \
+      --namespace aad-pi-webhook-system \
+      --wait
+    # adding a sleep here because the cert mount is not ready immediately after the deploy
+    sleep 120
+    make test-e2e-run
+  fi
 
   ${HELM} upgrade --install pod-identity-webhook "${REPO_ROOT}/manifest_staging/charts/pod-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/aad-pod-managed-identity/webhook}" \


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Managed Identity? Why is it needed? -->
- The `v0.3.0` image is now available. Reenabling the helm upgrade tests. 

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-managed-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in AAD Pod Managed Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/aad-pod-managed-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #116 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
