### PR TITLE
feat: rename `TOKEN_FILE_PATH` to `AZURE_FEDERATED_TOKEN_FILE`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,15 @@ $(HELM):
 	rm -rf helm* $(OS)-$(GOARCH)
 
 ## --------------------------------------
+## E2E images
+## --------------------------------------
+MSAL_GO_E2E_IMAGE := $(REGISTRY)/msal-go-e2e:$(IMAGE_VERSION)
+
+.PHONY: docker-build-e2e-msal-go
+docker-build-e2e-msal-go:
+	docker buildx build --no-cache -t $(MSAL_GO_E2E_IMAGE) -f examples/msal-go/Dockerfile --platform="linux/amd64" --output=$(OUTPUT_TYPE) examples/msal-go
+
+## --------------------------------------
 ## Testing
 ## --------------------------------------
 
@@ -246,7 +255,7 @@ GINKGO_ARGS ?= -focus="$(GINKGO_FOCUS)" -skip="$(GINKGO_SKIP)" -nodes=$(GINKGO_N
 
 # E2E configurations
 KUBECONFIG ?= $(HOME)/.kube/config
-E2E_ARGS := -kubeconfig=$(KUBECONFIG) -report-dir=$(PWD)/_artifacts -e2e.arc-cluster=$(ARC_CLUSTER)
+E2E_ARGS := -kubeconfig=$(KUBECONFIG) -report-dir=$(PWD)/_artifacts -e2e.arc-cluster=$(ARC_CLUSTER) -e2e.token-exchange-image=$(MSAL_GO_E2E_IMAGE)
 E2E_EXTRA_ARGS ?=
 
 .PHONY: test-e2e-run
@@ -271,6 +280,7 @@ kind-create: $(KIND) $(KUBECTL)
 .PHONY: kind-load-image
 kind-load-image:
 	$(KIND) load docker-image $(WEBHOOK_IMAGE) --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image $(MSAL_GO_E2E_IMAGE) --name $(KIND_CLUSTER_NAME)
 
 .PHONY: kind-delete
 kind-delete: $(KIND)

--- a/examples/msal-go/Dockerfile
+++ b/examples/msal-go/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:1.16 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY token_credential.go token_credential.go
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o msalgo .
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/msalgo .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/msalgo"]

--- a/examples/msal-go/main.go
+++ b/examples/msal-go/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
 	"github.com/Azure/go-autorest/autorest"
@@ -20,9 +21,14 @@ func main() {
 	kvClient := keyvault.New()
 	kvClient.Authorizer = autorest.NewBearerAuthorizerCallback(nil, clientAssertionBearerAuthorizerCallback)
 
-	secretBundle, err := kvClient.GetSecret(context.Background(), keyvaultURL, secretName, "")
-	if err != nil {
-		klog.Fatalf("failed to get secret from keyvault, err: %+v", err)
+	for {
+		secretBundle, err := kvClient.GetSecret(context.Background(), keyvaultURL, secretName, "")
+		if err != nil {
+			klog.Fatalf("failed to get secret from keyvault, err: %+v", err)
+		}
+		klog.InfoS("successfully got secret", "secret", *secretBundle.Value)
+
+		// wait for 60 seconds before polling again
+		time.Sleep(60 * time.Second)
 	}
-	klog.InfoS("successfully got secret", "secret", *secretBundle.Value)
 }

--- a/examples/msal-go/token_credential.go
+++ b/examples/msal-go/token_credential.go
@@ -26,9 +26,9 @@ func clientAssertionBearerAuthorizerCallback(tenantID, resource string) (*autore
 	// 	AZURE_CLIENT_ID with the clientID set in the service account annotation
 	// 	AZURE_TENANT_ID with the tenantID set in the service account annotation. If not defined, then
 	// 	the tenantID provided via aad-pi-webhook-config for the webhook will be used.
-	// 	TOKEN_FILE_PATH is the service account token path
+	// 	AZURE_FEDERATED_TOKEN_FILE is the service account token path
 	clientID := os.Getenv("AZURE_CLIENT_ID")
-	tokenFilePath := os.Getenv("TOKEN_FILE_PATH")
+	tokenFilePath := os.Getenv("AZURE_FEDERATED_TOKEN_FILE")
 
 	// generate a token using the msal confidential client
 	// this will always generate a new token request to AAD

--- a/examples/msal-net/akvdotnet/TokenCredential.cs
+++ b/examples/msal-net/akvdotnet/TokenCredential.cs
@@ -17,9 +17,9 @@ public class MyClientAssertionCredential : TokenCredential
         // 	AZURE_CLIENT_ID with the clientID set in the service account annotation
         // 	AZURE_TENANT_ID with the tenantID set in the service account annotation. If not defined, then
         // 		the tenantID provided via aad-pi-webhook-config for the webhook will be used.
-        // 	TOKEN_FILE_PATH is the service account token path
+        // 	AZURE_FEDERATED_TOKEN_FILE is the service account token path
         var clientID = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
-        var tokenPath = Environment.GetEnvironmentVariable("TOKEN_FILE_PATH");
+        var tokenPath = Environment.GetEnvironmentVariable("AZURE_FEDERATED_TOKEN_FILE");
         var tenantID = Environment.GetEnvironmentVariable("AZURE_TENANT_ID");
 
         _confidentialClientApp = ConfidentialClientApplicationBuilder.Create(clientID)

--- a/pkg/webhook/consts.go
+++ b/pkg/webhook/consts.go
@@ -24,12 +24,12 @@ const (
 
 // Environment variables injected in the pod
 const (
-	AzureClientIDEnvVar      = "AZURE_CLIENT_ID"
-	AzureTenantIDEnvVar      = "AZURE_TENANT_ID"
-	TokenFilePathEnvVar      = "TOKEN_FILE_PATH" // #nosec
-	AzureAuthorityHostEnvVar = "AZURE_AUTHORITY_HOST"
-	TokenFilePathName        = "azure-identity-token"
-	TokenFileMountPath       = "/var/run/secrets/tokens" // #nosec
+	AzureClientIDEnvVar           = "AZURE_CLIENT_ID"
+	AzureTenantIDEnvVar           = "AZURE_TENANT_ID"
+	AzureFederatedTokenFileEnvVar = "AZURE_FEDERATED_TOKEN_FILE" // #nosec
+	AzureAuthorityHostEnvVar      = "AZURE_AUTHORITY_HOST"
+	TokenFilePathName             = "azure-identity-token"
+	TokenFileMountPath            = "/var/run/secrets/tokens" // #nosec
 	// DefaultAudience is the audience added to the service account token audience
 	// This value is to be consistent with other token exchange flows in AAD and has
 	// no impact on the actual token exchange flow.

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -228,9 +228,9 @@ func addEnvironmentVariables(container corev1.Container, clientID, tenantID, azu
 	if _, ok := m[AzureTenantIDEnvVar]; !ok {
 		container.Env = append(container.Env, corev1.EnvVar{Name: AzureTenantIDEnvVar, Value: tenantID})
 	}
-	// add the token file path env var
-	if _, ok := m[TokenFilePathEnvVar]; !ok {
-		container.Env = append(container.Env, corev1.EnvVar{Name: TokenFilePathEnvVar, Value: filepath.Join(TokenFileMountPath, TokenFilePathName)})
+	// add the token file env var
+	if _, ok := m[AzureFederatedTokenFileEnvVar]; !ok {
+		container.Env = append(container.Env, corev1.EnvVar{Name: AzureFederatedTokenFileEnvVar, Value: filepath.Join(TokenFileMountPath, TokenFilePathName)})
 	}
 	// add the azure authority host env var
 	if _, ok := m[AzureAuthorityHostEnvVar]; !ok {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -509,15 +509,15 @@ func TestAddEnvironmentVariables(t *testing.T) {
 						Value: "clientID",
 					},
 					{
-						Name:  "AZURE_TENANT_ID",
+						Name:  AzureTenantIDEnvVar,
 						Value: "tenantID",
 					},
 					{
-						Name:  "TOKEN_FILE_PATH",
+						Name:  AzureFederatedTokenFileEnvVar,
 						Value: filepath.Join(TokenFileMountPath, TokenFilePathName),
 					},
 					{
-						Name:  "AZURE_AUTHORITY_HOST",
+						Name:  AzureAuthorityHostEnvVar,
 						Value: "https://login.microsoftonline.com/",
 					},
 				},
@@ -534,15 +534,15 @@ func TestAddEnvironmentVariables(t *testing.T) {
 						Value: "myClientID",
 					},
 					{
-						Name:  "AZURE_TENANT_ID",
+						Name:  AzureTenantIDEnvVar,
 						Value: "myTenantID",
 					},
 					{
-						Name:  "TOKEN_FILE_PATH",
+						Name:  AzureFederatedTokenFileEnvVar,
 						Value: filepath.Join(TokenFileMountPath, TokenFilePathName),
 					},
 					{
-						Name:  "AZURE_AUTHORITY_HOST",
+						Name:  AzureAuthorityHostEnvVar,
 						Value: "https://login.microsoftonline.com/",
 					},
 				},
@@ -556,15 +556,15 @@ func TestAddEnvironmentVariables(t *testing.T) {
 						Value: "myClientID",
 					},
 					{
-						Name:  "AZURE_TENANT_ID",
+						Name:  AzureTenantIDEnvVar,
 						Value: "myTenantID",
 					},
 					{
-						Name:  "TOKEN_FILE_PATH",
+						Name:  AzureFederatedTokenFileEnvVar,
 						Value: filepath.Join(TokenFileMountPath, TokenFilePathName),
 					},
 					{
-						Name:  "AZURE_AUTHORITY_HOST",
+						Name:  AzureAuthorityHostEnvVar,
 						Value: "https://login.microsoftonline.com/",
 					},
 				},
@@ -595,15 +595,15 @@ func TestAddEnvironmentVariables(t *testing.T) {
 						Value: "clientID",
 					},
 					{
-						Name:  "AZURE_TENANT_ID",
+						Name:  AzureTenantIDEnvVar,
 						Value: "tenantID",
 					},
 					{
-						Name:  "TOKEN_FILE_PATH",
+						Name:  AzureFederatedTokenFileEnvVar,
 						Value: filepath.Join(TokenFileMountPath, TokenFilePathName),
 					},
 					{
-						Name:  "AZURE_AUTHORITY_HOST",
+						Name:  AzureAuthorityHostEnvVar,
 						Value: "https://login.microsoftonline.com/",
 					},
 				},

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -20,7 +20,7 @@ create_cluster() {
     download_service_account_keys
     # create a kind cluster, then build and load the webhook manager image to the kind cluster
     make kind-create
-    [[ "${SKIP_IMAGE_BUILD:-}" == "true" ]] || OUTPUT_TYPE="type=docker" make docker-build-webhook
+    [[ "${SKIP_IMAGE_BUILD:-}" == "true" ]] || OUTPUT_TYPE="type=docker" make docker-build-webhook docker-build-e2e-msal-go
     make kind-load-image
   else
     : "${REGISTRY:?Environment variable empty or not defined.}"
@@ -106,7 +106,10 @@ test_helm_chart() {
     --namespace aad-pi-webhook-system \
     --wait
   poll_webhook_readiness
-  make test-e2e-run
+  # TODO (aramase) remove token exchange from GINKGO_SKIP after v0.4.0 release is published
+  # Skipping TokenExchange test for the current release as we're using the latest msal-go image
+  # which is updated to use AZURE_FEDERATED_TOKEN_FILE for token path.
+  GINKGO_SKIP=TokenExchange make test-e2e-run
 
   ${HELM} upgrade --install pod-identity-webhook "${REPO_ROOT}/manifest_staging/charts/pod-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/aad-pod-managed-identity/webhook}" \

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -25,9 +25,10 @@ import (
 )
 
 var (
-	arcCluster     bool
-	c              *kubernetes.Clientset
-	coreNamespaces = []string{
+	arcCluster            bool
+	tokenExchangeE2EImage string
+	c                     *kubernetes.Clientset
+	coreNamespaces        = []string{
 		metav1.NamespaceSystem,
 		"aad-pi-webhook-system",
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -13,6 +13,7 @@ import (
 
 func init() {
 	flag.BoolVar(&arcCluster, "e2e.arc-cluster", false, "Running on an arc-enabled cluster")
+	flag.StringVar(&tokenExchangeE2EImage, "e2e.token-exchange-image", "aramase/dotnet:v0.4", "The image to use for token exchange tests")
 }
 
 // handleFlags sets up all flags and parses the command line.

--- a/test/e2e/token_exchange.go
+++ b/test/e2e/token_exchange.go
@@ -21,7 +21,7 @@ import (
 var _ = ginkgo.Describe("TokenExchange [KindOnly]", func() {
 	f := framework.NewDefaultFramework("token-exchange")
 
-	// E2E scenario from https://github.com/Azure/aad-pod-managed-identity/tree/main/examples/msal-net/akvdotnet
+	// E2E scenario from https://github.com/Azure/aad-pod-managed-identity/tree/main/examples/msal-go
 	ginkgo.It("should exchange the service account token for a valid AAD token", func() {
 		clientID, ok := os.LookupEnv("APPLICATION_CLIENT_ID")
 		gomega.Expect(ok).To(gomega.BeTrue(), "APPLICATION_CLIENT_ID must be set")
@@ -39,7 +39,7 @@ var _ = ginkgo.Describe("TokenExchange [KindOnly]", func() {
 			f.ClientSet,
 			namespace,
 			serviceAccount,
-			"aramase/dotnet:v0.4",
+			tokenExchangeE2EImage,
 			nil,
 			nil,
 			[]corev1.EnvVar{{
@@ -63,7 +63,7 @@ var _ = ginkgo.Describe("TokenExchange [KindOnly]", func() {
 					return false
 				}
 				framework.Logf("stdout: %s", stdout)
-				return strings.Contains(stdout, "Your secret is Hello!")
+				return strings.Contains(stdout, `"successfully got secret" secret="Hello!"`)
 			}, framework.PollShortTimeout, framework.Poll).Should(gomega.BeTrue())
 		}
 	})


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Managed Identity? Why is it needed? -->
- Renames  `TOKEN_FILE_PATH` to `AZURE_FEDERATED_TOKEN_FILE`

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-managed-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in AAD Pod Managed Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/aad-pod-managed-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
ref #56 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
