### PR TITLE
ci: replace kind cluster version v1.18.19 with v1.22.0

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -145,14 +145,14 @@ jobs:
         value: "true"
     strategy:
       matrix:
-        kind_v1_18_19:
-          KIND_NODE_VERSION: v1.18.19
         kind_v1_19_11:
           KIND_NODE_VERSION: v1.19.11
         kind_v1_20_7:
           KIND_NODE_VERSION: v1.20.7
         kind_v1_21_2:
           KIND_NODE_VERSION: v1.21.2
+        kind_v1_22_0:
+          KIND_NODE_VERSION: v1.22.0
     steps:
       - script: make test-e2e
         displayName: Webhook E2E test suite

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -81,10 +81,6 @@ jobs:
           REGISTRY: upstreamk8sci.azurecr.io/aad-pod-managed-identity
           ARC_CLUSTER: "true"
           GINKGO_SKIP: \[KindOnly\]
-        kind_v1_18_19:
-          KIND_NODE_VERSION: v1.18.19
-          LOCAL_ONLY: "true"
-          TEST_HELM_CHART: "true"
         kind_v1_19_11:
           KIND_NODE_VERSION: v1.19.11
           LOCAL_ONLY: "true"
@@ -95,6 +91,10 @@ jobs:
           TEST_HELM_CHART: "true"
         kind_v1_21_2:
           KIND_NODE_VERSION: v1.21.2
+          LOCAL_ONLY: "true"
+          TEST_HELM_CHART: "true"
+        kind_v1_22_0:
+          KIND_NODE_VERSION: v1.22.0
           LOCAL_ONLY: "true"
           TEST_HELM_CHART: "true"
     steps:

--- a/scripts/create-kind-cluster.sh
+++ b/scripts/create-kind-cluster.sh
@@ -59,7 +59,7 @@ EOF
 
 create_kind_cluster() {
   # create a kind cluster
-  cat <<EOF | ${KIND} create cluster --name "${KIND_CLUSTER_NAME}" --image "kindest/node:${KIND_NODE_VERSION:-v1.21.2}" --config=-
+  cat <<EOF | ${KIND} create cluster --name "${KIND_CLUSTER_NAME}" --image "kindest/node:${KIND_NODE_VERSION:-v1.22.0}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Managed Identity? Why is it needed? -->

v1.18.x is considered EOL, replacing it with v1.22.0.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/aad-pod-managed-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in AAD Pod Managed Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/aad-pod-managed-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
