### PR TITLE
security: fix CVE-2021-3711, CVE-2021-3712

### DIFF
--- a/docker/init.Dockerfile
+++ b/docker/init.Dockerfile
@@ -1,6 +1,7 @@
 FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.6.6
 
-RUN clean-install ca-certificates
+# upgrading libssl1.1 due to CVE-2021-33910 and CVE-2021-3712
+RUN clean-install ca-certificates libssl1.1
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in AAD Pod Managed Identity? Why is it needed? -->
Fixes the following CVEs:

```bash
+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
|  LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                TITLE                 |
+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
| libssl1.1 | CVE-2021-3711    | HIGH     | 1.1.1d-0+deb10u6  | 1.1.1d-0+deb10u7 | openssl: SM2 Decryption              |
|           |                  |          |                   |                  | Buffer Overflow                      |
|           |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3711 |
+           +------------------+----------+                   +                  +--------------------------------------+
|           | CVE-2021-3712    | MEDIUM   |                   |                  | openssl: Read buffer overruns        |
|           |                  |          |                   |                  | processing ASN.1 strings             |
|           |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3712 |
+-----------+------------------+----------+-------------------+------------------+--------------------------------------+
```

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in AAD Pod Managed Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
