### PR TITLE
test: reenable upgrade tests and update validate mutated pod check

### DIFF
--- a/docs/book/src/concepts.md
+++ b/docs/book/src/concepts.md
@@ -22,23 +22,23 @@ Azure AD Workload Identity uses a [mutating admission webhook][6] to inject the 
 
 ### Environment Variables
 
-| Environment variable   | Description                                           |
-|------------------------|-------------------------------------------------------|
-| `AZURE_AUTHORITY_HOST` | The Azure Active Directory (AAD) endpoint.            |
-| `AZURE_CLIENT_ID`      | The client ID of the identity.                        |
-| `AZURE_TENANT_ID`      | The tenant ID of the Azure account.                   |
-| `TOKEN_FILE_PATH`      | The path of the projected service account token file. |
+| Environment variable         | Description                                           |
+| ---------------------------- | ----------------------------------------------------- |
+| `AZURE_AUTHORITY_HOST`       | The Azure Active Directory (AAD) endpoint.            |
+| `AZURE_CLIENT_ID`            | The client ID of the identity.                        |
+| `AZURE_TENANT_ID`            | The tenant ID of the Azure account.                   |
+| `AZURE_FEDERATED_TOKEN_FILE` | The path of the projected service account token file. |
 
 ### Volumes
 
 | Volume                 | Description                           |
-|------------------------|---------------------------------------|
+| ---------------------- | ------------------------------------- |
 | `azure-identity-token` | The projected service account volume. |
 
 ### Volume Mounts
 
 | Volume mount                                   | Description                                           |
-|------------------------------------------------|-------------------------------------------------------|
+| ---------------------------------------------- | ----------------------------------------------------- |
 | `/var/run/secrets/tokens/azure-identity-token` | The path of the projected service account token file. |
 
 With these properties injected, the webhook allows pods to use a [service account token][7] projected to its volume to exchange for a valid AAD token using the [Microsoft Authentication Library][8] (MSAL).

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -439,23 +439,23 @@ kubectl describe pod quick-start
 
 You can verify the following injected properties in the output:
 
-| Environment variable   | Description                                           |
-|------------------------|-------------------------------------------------------|
-| `AZURE_AUTHORITY_HOST` | The Azure Active Directory (AAD) endpoint.            |
-| `AZURE_CLIENT_ID`      | The client ID of the AAD application.                 |
-| `AZURE_TENANT_ID`      | The tenant ID of the registered AAD application.      |
-| `TOKEN_FILE_PATH`      | The path of the projected service account token file. |
+| Environment variable         | Description                                           |
+| ---------------------------- | ----------------------------------------------------- |
+| `AZURE_AUTHORITY_HOST`       | The Azure Active Directory (AAD) endpoint.            |
+| `AZURE_CLIENT_ID`            | The client ID of the AAD application.                 |
+| `AZURE_TENANT_ID`            | The tenant ID of the registered AAD application.      |
+| `AZURE_FEDERATED_TOKEN_FILE` | The path of the projected service account token file. |
 
 <br/>
 
 | Volume mount                                   | Description                                           |
-|------------------------------------------------|-------------------------------------------------------|
+| ---------------------------------------------- | ----------------------------------------------------- |
 | `/var/run/secrets/tokens/azure-identity-token` | The path of the projected service account token file. |
 
 <br/>
 
 | Volume                 | Description                           |
-|------------------------|---------------------------------------|
+| ---------------------- | ------------------------------------- |
 | `azure-identity-token` | The projected service account volume. |
 
 ```log
@@ -482,12 +482,12 @@ Containers:
     Ready:          True
     Restart Count:  0
     Environment:
-      KEYVAULT_NAME:        ${KEYVAULT_NAME}
-      SECRET_NAME:          ${KEYVAULT_SECRET_NAME}
-      AZURE_AUTHORITY_HOST: (Injected by the webhook)
-      AZURE_CLIENT_ID:      (Injected by the webhook)
-      AZURE_TENANT_ID:      (Injected by the webhook)
-      TOKEN_FILE_PATH:      (Injected by the webhook)
+      KEYVAULT_NAME:              ${KEYVAULT_NAME}
+      SECRET_NAME:                ${KEYVAULT_SECRET_NAME}
+      AZURE_AUTHORITY_HOST:       (Injected by the webhook)
+      AZURE_CLIENT_ID:            (Injected by the webhook)
+      AZURE_TENANT_ID:            (Injected by the webhook)
+      AZURE_FEDERATED_TOKEN_FILE: (Injected by the webhook)
     Mounts:
       /var/run/secrets/kubernetes.io/serviceaccount from workload-identity-sa-token-mlgn8 (ro)
       /var/run/secrets/tokens from azure-identity-token (ro) (Injected by the webhook)
@@ -561,6 +561,6 @@ az ad sp delete --id "${APPLICATION_CLIENT_ID}"
 
 [6]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 
-[7]: https://github.com/Azure/aad-pod-managed-identity/blob/c6b92d50910091441a71c1cb32517d53649d74e7/manifest_staging/deploy/aad-pi-webhook.yaml#L45-L46
+[7]: https://github.com/Azure/azure-workload-identity/blob/1cb9d78159458b0c820c9c08fadf967833c8cdb4/deploy/azure-wi-webhook.yaml#L103-L104
 
 [8]: https://portal.azure.com/#cloudshell/

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -101,18 +101,13 @@ test_helm_chart() {
   ${KUBECTL} create namespace azure-workload-identity-system
 
   # test helm upgrade from chart to manifest_staging/chart
-  # TODO (aramase) reenable upgrade tests after v0.4.0 release once rename azure-workload-identity is complete
 
-  # ${HELM} install workload-identity-webhook "${REPO_ROOT}/charts/workload-identity-webhook" \
-  #   --set azureTenantID="${AZURE_TENANT_ID}" \
-  #   --namespace azure-workload-identity-system \
-  #   --wait
-  # poll_webhook_readiness
-
-  # TODO (aramase) remove token exchange and proxy from GINKGO_SKIP after v0.4.0 release is published
-  # Skipping TokenExchange test for the current release as we're using the latest msal-go image
-  # which is updated to use AZURE_FEDERATED_TOKEN_FILE for token path.
-  # GINKGO_SKIP=TokenExchange\|Proxy make test-e2e-run
+  ${HELM} install workload-identity-webhook "${REPO_ROOT}/charts/workload-identity-webhook" \
+    --set azureTenantID="${AZURE_TENANT_ID}" \
+    --namespace azure-workload-identity-system \
+    --wait
+  poll_webhook_readiness
+  make test-e2e-run
 
   ${HELM} upgrade --install workload-identity-webhook "${REPO_ROOT}/manifest_staging/charts/workload-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/workload-identity/webhook}" \

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -233,22 +233,11 @@ func validateMutatedPod(f *framework.Framework, pod *corev1.Pod, skipContainers 
 			webhook.AzureClientIDEnvVar,
 			webhook.AzureTenantIDEnvVar,
 			webhook.AzureAuthorityHostEnvVar,
+			webhook.AzureFederatedTokenFileEnvVar,
 		} {
 			if _, ok := m[injected]; !ok {
 				framework.Failf("container %s in pod %s does not have env var %s injected", container.Name, pod.Name, injected)
 			}
-		}
-
-		// v0.3.0 injects the token file path as TOKEN_FILE_PATH environment variable. For v0.3.0+ the environment variable
-		// is updated to AZURE_FEDERATED_TOKEN_FILE. Adding this check to support upgrade tests from v0.3.0 to v0.3.0+
-		// TODO (aramase) remove this after v0.4.0
-		framework.Logf("ensuring that the token file path environment variable is injected to %s in %s", container.Name, pod.Name)
-		tokenFilePathSet := false
-		if _, ok := m["TOKEN_FILE_PATH"]; ok {
-			tokenFilePathSet = true
-		}
-		if _, ok := m[webhook.AzureFederatedTokenFileEnvVar]; !ok && !tokenFilePathSet {
-			framework.Failf("container %s in pod %s does not have env var %s injected", container.Name, pod.Name, webhook.AzureFederatedTokenFileEnvVar)
 		}
 
 		framework.Logf("ensuring that azure-identity-token is mounted to %s", container.Name)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Reenables upgrade tests as `v0.4.0` release is out.
- Updates docs to rename `TOKEN_FILE_PATH` to `AZURE_FEDEREDATED_TOKEN_FILE`
- Updates validate mutated pod check 

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #56 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
