### PR TITLE
ci: select Kubernetes versions based on region

### DIFF
--- a/.pipelines/templates/upgrade.yaml
+++ b/.pipelines/templates/upgrade.yaml
@@ -24,7 +24,14 @@ jobs:
         displayName: Webhook E2E test suite
         env:
           SKIP_CLEANUP: "true"
-      - script: az aks upgrade --resource-group "${CLUSTER_NAME}" --name "${CLUSTER_NAME}" --kubernetes-version 1.21.1 --yes > /dev/null
+      - script: |
+          # xref: https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/512316adc9daa2216de10a6288f6c1df8a122654/.pipelines/templates/aks-upgrade.yaml#L3-L8
+          MINOR_VERSION="$(az aks get-upgrades --resource-group ${CLUSTER_NAME} --name ${CLUSTER_NAME} --query "controlPlaneProfile.kubernetesVersion" | jq -r 'split(".") | .[:2] | join(".")')"
+          echo "Minor version is - ${MINOR_VERSION}"
+          UPGRADE_VERSION="$(az aks get-upgrades --resource-group ${CLUSTER_NAME} --name ${CLUSTER_NAME} --query "max(controlPlaneProfile.upgrades[?isPreview==null && !(starts_with(kubernetesVersion, '${MINOR_VERSION}'))].kubernetesVersion)" -otsv)"
+          echo "Upgrading to Kubernetes ${UPGRADE_VERSION}"
+
+          az aks upgrade --resource-group "${CLUSTER_NAME}" --name "${CLUSTER_NAME}" --kubernetes-version "${UPGRADE_VERSION}" --yes > /dev/null
         displayName: Upgrade cluster
       - script: make test-e2e
         displayName: Webhook E2E test suite


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Since regions might not have the same set of Kubernetes versions available, we have to select the Kubernetes versions based on where the cluster is going to be deployed.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/157

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
