### PR TITLE
docs: issue with file mode in Kubernetes 1.18

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -6,7 +6,7 @@
 - [Topics](./topics.md)
   - [Labels And Annotations](./topics/labels-and-annotations.md)
 - [Troubleshooting]()
-- [Known Limitations]()
+- [Known Issues](./known-issues.md)
 - [Development](./development.md)
   - [Releasing](./development/releasing.md)
 - [Contributing](./contributing.md)

--- a/docs/book/src/known-issues.md
+++ b/docs/book/src/known-issues.md
@@ -1,0 +1,23 @@
+# Known Issues
+
+## Permission denied when reading the projected service account token file
+
+In Kubernetes 1.18, the default mode for the projected service account token file is `0600`. This causes containers running as non-root to fail while trying to read the token file:
+
+```bash
+F0826 20:03:20.113998 1 main.go:27] failed to get secret from keyvault, err: autorest/Client#Do: Preparing request failed: StatusCode=0 -- Original Error: failed to read service account token: open /var/run/secrets/tokens/azure-identity-token: permission denied
+```
+
+The default mode was changed to `0644` in Kubernetes v1.19, which allows containers running as non-root to read the projected service account token.
+
+If you ran into this issue, you can either:
+
+1. Upgrade your cluster to v1.19+ or
+
+2. Apply the following `securityContext` field to your pod spec:
+
+```yaml
+spec:
+  securityContext:
+    fsGroup: 65534
+```


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Document issue with file mode in Kubernetes 1.18.

ref: #97

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #156

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
