### PR TITLE
feat: set number of replicas to 2 for High Availability

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   selector:
     matchLabels: {}
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels: {}

--- a/manifest_staging/charts/workload-identity-webhook/README.md
+++ b/manifest_staging/charts/workload-identity-webhook/README.md
@@ -32,7 +32,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | Parameter          | Description                                                              | Default                                                 |
 | :----------------- | :----------------------------------------------------------------------- | :------------------------------------------------------ |
 | labels             | The labels to add to the azure-workload-identity webhook pods            | `azure-workload-identity.io/system: "true"`             |
-| replicaCount       | The number of azure-workload-identity replicas to deploy for the webhook | `1`                                                     |
+| replicaCount       | The number of azure-workload-identity replicas to deploy for the webhook | `2`                                                     |
 | image.repository   | Image repository                                                         | `mcr.microsoft.com/oss/azure/workload-identity/webhook` |
 | image.pullPolicy   | Image pullPolicy                                                         | `IfNotPresent`                                          |
 | image.release      | The image release tag to use                                             | Current release version: `v0.4.0`                       |

--- a/manifest_staging/charts/workload-identity-webhook/values.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/values.yaml
@@ -4,7 +4,7 @@
 
 labels: 
   azure-workload-identity.io/system: "true"
-replicaCount: 1
+replicaCount: 2
 image:
   repository: mcr.microsoft.com/oss/azure/workload-identity/webhook
   pullPolicy: IfNotPresent

--- a/manifest_staging/deploy/azure-wi-webhook.yaml
+++ b/manifest_staging/deploy/azure-wi-webhook.yaml
@@ -139,7 +139,7 @@ metadata:
   name: azure-wi-webhook-controller-manager
   namespace: azure-workload-identity-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       azure-workload-identity.io/system: "true"

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
@@ -32,7 +32,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | Parameter          | Description                                                              | Default                                                 |
 | :----------------- | :----------------------------------------------------------------------- | :------------------------------------------------------ |
 | labels             | The labels to add to the azure-workload-identity webhook pods            | `azure-workload-identity.io/system: "true"`             |
-| replicaCount       | The number of azure-workload-identity replicas to deploy for the webhook | `1`                                                     |
+| replicaCount       | The number of azure-workload-identity replicas to deploy for the webhook | `2`                                                     |
 | image.repository   | Image repository                                                         | `mcr.microsoft.com/oss/azure/workload-identity/webhook` |
 | image.pullPolicy   | Image pullPolicy                                                         | `IfNotPresent`                                          |
 | image.release      | The image release tag to use                                             | Current release version: `v0.4.0`                       |

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
@@ -4,7 +4,7 @@
 
 labels: 
   azure-workload-identity.io/system: "true"
-replicaCount: 1
+replicaCount: 2
 image:
   repository: mcr.microsoft.com/oss/azure/workload-identity/webhook
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
Sets the default number of replicas to 2 for High availability. The mutation requests will be load balanced across the 2 replicas. 

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/96

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
