### PR TITLE
feat: add webhook support for init containers

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -107,7 +107,8 @@ test_helm_chart() {
     --namespace azure-workload-identity-system \
     --wait
   poll_webhook_readiness
-  make test-e2e-run
+  # TODO(chewong): enable init containers test once v0.5.0 is released
+  GINKGO_SKIP=init.containers make test-e2e-run
 
   ${HELM} upgrade --install workload-identity-webhook "${REPO_ROOT}/manifest_staging/charts/workload-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/workload-identity/webhook}" \

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -209,7 +209,9 @@ func createSecretForArcCluster(c kubernetes.Interface, namespace, serviceAccount
 // 4. verify that the pod has access to token file via `cat /var/run/secrets/tokens/azure-identity-token`.
 func validateMutatedPod(f *framework.Framework, pod *corev1.Pod, skipContainers []string) {
 	withoutSkipContainers := []corev1.Container{}
-	for _, c := range pod.Spec.Containers {
+	// consider init containers as well
+	allContainers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
+	for _, c := range allContainers {
 		keepContainer := true
 		for _, skip := range skipContainers {
 			if c.Name == skip {


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Add webhook support for init containers.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #149.


**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
