### PR TITLE
docs: key rotation for self-managed clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Check out the Azure AD Workload Identity [Quick Start][4] to create your first a
 The repository contains the following components:
 
 1.  [Mutating Webhook][5]
-    > The webhook is for mutating pods that reference an annotated service account. The webhook will inject the environment variables and the projected service account token volume.
+    > The webhook is for mutating pods that reference an annotated service account. The webhook will inject the environment variables and the [projected service account token volume][11]. Your application/SDK will consume them to authenticate itself to Azure resources.
 
 2.  [Proxy Init][6] and [Proxy][7]
     > The proxy init container and proxy sidecar container will be used for applications that are still using [AAD Pod Identity][1].
@@ -51,3 +51,5 @@ The repository contains the following components:
 [9]: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=windows
 
 [10]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions
+
+[11]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -5,6 +5,7 @@
 [Concepts](./concepts.md)
 - [Topics](./topics.md)
   - [Labels And Annotations](./topics/labels-and-annotations.md)
+  - [Key Rotation For Self-Managed Clusters](./topics/key-rotation-for-self-managed-clusters.md)
 - [Troubleshooting]()
 - [Known Issues](./known-issues.md)
 - [Development](./development.md)

--- a/docs/book/src/development.md
+++ b/docs/book/src/development.md
@@ -6,7 +6,7 @@
 
 ### Base requirements
 
-1. Prerequisites from [quickstart](https://azure.github.io/azure-workload-identity/quick-start.html#prerequisites)
+1. Prerequisites from [Quick Start](https://azure.github.io/azure-workload-identity/quick-start.html#prerequisites)
 2. Install [go](https://golang.org/dl/)
    - Get the latest patch version for go 1.17.
 3. Install [jq](https://stedolan.github.io/jq/)
@@ -83,16 +83,24 @@ az storage blob upload \
   --name .well-known/openid-configuration
 ```
 
-Generate and upload the JWKS:
+Install the `generate-jwks` tool:
+
+> Make sure the environment variable `GOBIN` is defined and it is part of your `PATH`.
 
 ```bash
 pushd hack/generate-jwks
-go run main.go --public-keys ../../sa.pub | jq > jwks.json
+go install .
+popd
+```
+
+Generate and upload the JWKS:
+
+```bash
+generate-jwks --public-keys sa.pub > jwks.json
 az storage blob upload \
   --container-name "${AZURE_STORAGE_CONTAINER}" \
   --file jwks.json \
   --name openid/v1/jwks
-popd
 ```
 
 Verify that the OIDC discovery document is publicly accessible:

--- a/docs/book/src/topics/key-rotation-for-self-managed-clusters.md
+++ b/docs/book/src/topics/key-rotation-for-self-managed-clusters.md
@@ -1,0 +1,204 @@
+# Key Rotation For Self-Managed Clusters
+
+<!-- toc -->
+
+A security best practice is to routinely rotate your key pair used to sign the service account tokens. This page explains how to generate and rotate it in the case of self-managed Kubernetes clusters where you have access to the control plane.
+
+> This technique requires that the Kubernetes control plane is running in a high-availability (HA) setup with multiple API servers. Clusters that use a single API server will become unavailable while the API server is restarted.
+
+## 1. Generate a new key pair
+
+> Skip this step if you are planning to bring your own keys.
+
+```bash
+openssl genrsa -out sa-new.key 2048
+openssl rsa -in sa-new.key -pubout -out sa-new.pub
+```
+
+## 2. Backup the old key pair and distribute the new key pair
+
+Schedule a jump pod to each control plane node, which mounts the `/etc/kubernetes/pki` folder:
+
+> `/etc/kubernetes/pki/sa.pub` and `/etc/kubernetes/pki/sa.key` are the paths of the service account key pair for a kind cluster. The paths can vary depending on your provider.
+
+```bash
+cat << EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: jump
+  labels:
+    k8s-app: jump
+spec:
+  selector:
+    matchLabels:
+      name: jump
+  template:
+    metadata:
+      labels:
+        name: jump
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+        - name: busybox
+          image: busybox
+          command:
+            - sleep
+            - "3600"
+          volumeMounts:
+              - mountPath: /etc/kubernetes/pki
+                name: etc-kubernetes-pki
+      volumes:
+        - name: etc-kubernetes-pki
+          hostPath:
+            path: /etc/kubernetes/pki
+EOF
+```
+
+Backup the old service account key pair to your local machine:
+
+```bash
+POD_NAME="$(kubectl get po -l name=jump -ojson | jq -r '.items[0].metadata.name')"
+kubectl cp default/${POD_NAME}:/etc/kubernetes/pki/sa.pub sa-old.pub
+kubectl cp default/${POD_NAME}:/etc/kubernetes/pki/sa.key sa-old.key
+```
+
+Distribute the new key pair to the certificate directory of each control plane node:
+
+```bash
+for POD_NAME in "$(kubectl get po -l name=jump -ojson | jq -r '.items[].metadata.name')"; do
+  kubectl cp sa-new.pub default/${POD_NAME}:/etc/kubernetes/pki/sa-new.pub
+  kubectl cp sa-new.key default/${POD_NAME}:/etc/kubernetes/pki/sa-new.key
+done
+```
+
+## 3. Update the JWKS
+
+In the case of service account tokens generated before you initiated the key rotation, you would need a time period where the old and new public keys exist in the JWKS. The relying party can then validate service account tokens signed by both the old and new private key.
+
+Install the `generate-jwks` tool:
+
+> Make sure the environment variable `GOBIN` is defined and it is part of your `PATH`.
+
+```bash
+pushd hack/generate-jwks
+go install .
+popd
+```
+
+Generate and upload the JWKS:
+
+> Assuming you followed our [Quick Start][2] and store your OIDC discovery document and JWKS in an Azure storage account.
+
+```bash
+generate-jwks --public-keys sa-old.pub,sa-new.pub > jwks.json
+export AZURE_STORAGE_ACCOUNT=<AzureStorageAccount>
+az storage blob upload \
+  --container-name "${AZURE_STORAGE_CONTAINER}" \
+  --file jwks.json \
+  --name openid/v1/jwks
+```
+
+## 4. Key Rotation
+
+With the new key pair distributed, you can utilize [kubectl-node-shell][1] to update the following core components arguments by spawning a root shell to each control plane node:
+
+```bash
+kubectl node-shell <NodeName>
+
+# Run in the root shell
+# download yq (jq for yaml)
+curl -L https://github.com/mikefarah/yq/releases/download/v4.12.1/yq_linux_amd64 --output /usr/bin/yq
+chmod +x /usr/bin/yq
+
+# append the new public key as an kube-apiserver argument
+yq eval -i '.spec.containers[0].command |= . + ["--service-account-key-file=/etc/kubernetes/pki/sa-new.pub"]' /etc/kubernetes/manifests/kube-apiserver.yaml
+
+# replace the old private key with the new private key for kube-apiserver and kube-controller-manager
+sed -i 's|--service-account-signing-key-file=.*|--service-account-signing-key-file=/etc/kubernetes/pki/sa-new.key|' /etc/kubernetes/manifests/kube-apiserver.yaml
+sed -i 's|--service-account-private-key-file=.*|--service-account-private-key-file=/etc/kubernetes/pki/sa-new.key|' /etc/kubernetes/manifests/kube-controller-manager.yaml
+```
+
+The commands above should trigger a restart for kube-apiserver and kube-controller-manager pod.
+
+## 5. Verification
+
+Create a dummy pod that uses an annotated service account.
+
+```bash
+cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    azure.workload.identity/client-id: dummy
+  labels:
+    azure.workload.identity/use: "true"
+  name: workload-identity-sa
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy-pod
+spec:
+  serviceAccountName: workload-identity-sa
+  containers:
+    - name: busybox
+      image: busybox
+      command:
+        - sleep
+        - "3600"
+EOF
+```
+
+Output the projected service account token:
+
+```bash
+kubectl exec dummy-pod -- cat /var/run/secrets/tokens/azure-identity-token
+```
+
+Decode your token using [jwt.io][3]. The `kid` field in the token header should be the same as the `kid` of `generate-jwks --public-keys sa-new.pub | jq -r '.keys[0].kid'`. This means that the service account token is signed by the new private key.
+
+## 6. Cleanup
+
+Delete the dangling resources created above:
+
+```bash
+kubectl delete ds jump
+kubectl delete pod dummy-pod
+kubectl delete sa workload-identity-sa
+```
+
+## 7. Remove old JWK after maximum token expiration
+
+After the maximum token expiration (the default expiration is 24 hours) has passed, projected service account tokens signed by the old private key will be rotated by kubelet and signed with the new signing key. The kubelet proactively rotates the token if it is older than 80% of its total TTL, or if the token is older than 24 hours. You should update the JWKS accordingly to only include the new public key:
+
+```bash
+generate-jwks --public-keys sa-new.pub | jq > jwks.json
+az storage blob upload \
+  --container-name "${AZURE_STORAGE_CONTAINER}" \
+  --file jwks.json \
+  --name openid/v1/jwks
+```
+
+Remove the old public key from kube-apiserver's arguments:
+
+```bash
+# get the index of the old public key from the kube-apiserver argument array
+INDEX="$(yq e '.spec.containers[0].command' /etc/kubernetes/manifests/kube-apiserver.yaml | grep -Fn 'service-account-key-file' | head -n 1 | cut -d':' -f1)"
+
+# convert to zero-index
+INDEX="$(expr ${INDEX} - 1)"
+
+# remove the old public key argument using yq
+yq eval -i "del(.spec.containers[0].command[${INDEX}])" /etc/kubernetes/manifests/kube-apiserver.yaml
+```
+
+[1]: https://github.com/kvaps/kubectl-node-shell
+
+[2]: ../../quick-start.html
+
+[3]: https://jwt.io/

--- a/hack/generate-jwks/README.md
+++ b/hack/generate-jwks/README.md
@@ -3,13 +3,15 @@
 Use the go file to generate the JSON Web Key Sets (JWKS).
 
 ```bash
-go run main.go --public-keys <comma separated list of public keys>
+cd hack/generate-jwks
+go install .
+generate-jwks --public-keys <comma separated list of public keys>
 ```
 
 Sample output:
 
 ```bash
-➜ go run main.go --public-keys /tmp/apiserver.crt | jq
+➜ generate-jwks --public-keys /tmp/apiserver.crt
 {
   "keys": [
     {

--- a/hack/generate-jwks/main.go
+++ b/hack/generate-jwks/main.go
@@ -49,7 +49,7 @@ func main() {
 	if err != nil {
 		klog.Fatalf("failed to generate jwks: %v", err)
 	}
-	keysetJSON, err := json.Marshal(keyset)
+	keysetJSON, err := json.MarshalIndent(keyset, "", "  ")
 	if err != nil {
 		klog.Fatalf("failed to marshal service account issuer JWKS: %v", err)
 	}

--- a/scripts/create-kind-cluster.sh
+++ b/scripts/create-kind-cluster.sh
@@ -47,7 +47,7 @@ EOF
   fi
   if ! curl -sSf "${SERVICE_ACCOUNT_ISSUER}openid/v1/jwks" > /dev/null 2>&1; then
     pushd hack/generate-jwks
-    JWKS="$(go run main.go --public-keys "${SERVICE_ACCOUNT_KEY_FILE}" | jq)"
+    JWKS="$(go run main.go --public-keys "${SERVICE_ACCOUNT_KEY_FILE}")"
     popd
     cat <<EOF
 ${SERVICE_ACCOUNT_ISSUER}openid/v1/jwks is missing. You can upload the following JSON to the storage account:


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Documentations on how to perform key rotations for self-managed clusters.

FIxes #6.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
