### PR TITLE
feat: support console log encoding with klogr

### DIFF
--- a/examples/msal-go/main.go
+++ b/examples/msal-go/main.go
@@ -24,7 +24,8 @@ func main() {
 	for {
 		secretBundle, err := kvClient.GetSecret(context.Background(), keyvaultURL, secretName, "")
 		if err != nil {
-			klog.Fatalf("failed to get secret from keyvault, err: %+v", err)
+			klog.ErrorS(err, "failed to get secret from keyvault", "keyvault", keyvaultName, "secretName", secretName)
+			os.Exit(1)
 		}
 		klog.InfoS("successfully got secret", "secret", *secretBundle.Value)
 

--- a/examples/msal-go/token_credential.go
+++ b/examples/msal-go/token_credential.go
@@ -39,11 +39,11 @@ func clientAssertionBearerAuthorizerCallback(tenantID, resource string) (*autore
 	// read the service account token from the filesystem
 	signedAssertion, err := readJWTFromFS(tokenFilePath)
 	if err != nil {
-		return nil, errors.Errorf("failed to read service account token: %v", err)
+		return nil, errors.Wrap(err, "failed to read service account token")
 	}
 	cred, err := confidential.NewCredFromAssertion(signedAssertion)
 	if err != nil {
-		return nil, errors.Errorf("failed to create confidential creds: %v", err)
+		return nil, errors.Wrap(err, "failed to create confidential creds")
 	}
 	// create the confidential client to request an AAD token
 	confidentialClientApp, err := confidential.New(
@@ -51,7 +51,7 @@ func clientAssertionBearerAuthorizerCallback(tenantID, resource string) (*autore
 		cred,
 		confidential.WithAuthority(fmt.Sprintf("%s%s/oauth2/token", authorityHost, tenantID)))
 	if err != nil {
-		return nil, errors.Errorf("failed to create confidential client app: %v", err)
+		return nil, errors.Wrap(err, "failed to create confidential client app")
 	}
 
 	// trim the suffix / if exists
@@ -63,7 +63,7 @@ func clientAssertionBearerAuthorizerCallback(tenantID, resource string) (*autore
 
 	result, err := confidentialClientApp.AcquireTokenByCredential(context.Background(), []string{resource})
 	if err != nil {
-		return nil, errors.Errorf("failed to get token: %v", err)
+		return nil, errors.Wrap(err, "failed to get token")
 	}
 
 	return autorest.NewBearerAuthorizer(authResult{

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.12
 	github.com/Azure/go-autorest/autorest/adal v0.9.5
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.3.0
+	github.com/go-logr/logr v0.4.0
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.16.4
@@ -34,7 +35,6 @@ require (
 	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/manifest_staging/charts/workload-identity-webhook/README.md
+++ b/manifest_staging/charts/workload-identity-webhook/README.md
@@ -46,6 +46,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | service.targetPort | Service target port                                                      | `9443`                                                  |
 | azureTenantID      | [**REQUIRED**] Azure tenant ID                                           | ``                                                      |
 | azureEnvironment   | Azure Environment                                                        | `AzurePublicCloud`                                      |
+| logEncoder         | The log encoder to use for the webhook manager (`json`, `console`)       | `console`                                               |
 
 ## Contributing Changes
 

--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-controller-manager-deployment.yaml
@@ -27,6 +27,7 @@ spec:
       containers:
       - args:
         - --arc-cluster={{ .Values.arcCluster }}
+        - --log-encoder={{ .Values.logEncoder }}
         command:
         - /manager
         env:

--- a/manifest_staging/charts/workload-identity-webhook/values.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-labels: 
+labels:
   azure-workload-identity.io/system: "true"
 replicaCount: 2
 image:
@@ -28,3 +28,4 @@ service:
   targetPort: 9443
 azureEnvironment: AzurePublicCloud
 azureTenantID:
+logEncoder: console

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,53 @@
+package logger
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// Encoder is an enum for the log encoders.
+type Encoder string
+
+// Logger is a wrapper for the log encoder.
+type Logger struct {
+	Encoder string
+}
+
+const (
+	logEncoderFlag = "log-encoder"
+
+	// EncoderConsole is the console encoder.
+	EncoderConsole Encoder = "console"
+
+	// EncoderJSON is the json encoder.
+	EncoderJSON Encoder = "json"
+)
+
+// New returns a new logger with console encoder as the default.
+func New() *Logger {
+	return &Logger{
+		Encoder: string(EncoderConsole),
+	}
+}
+
+// AddFlags adds flags for the logger.
+func (l *Logger) AddFlags() {
+	flag.StringVar(&l.Encoder, logEncoderFlag, string(EncoderConsole), fmt.Sprintf("Sets the log encoder (%s|%s)", EncoderConsole, EncoderJSON))
+}
+
+// Get returns a new logr.Logger according to the encoder.
+func (l *Logger) Get() logr.Logger {
+	switch Encoder(l.Encoder) {
+	case EncoderConsole:
+		// no-op
+	case EncoderJSON:
+		return zap.New()
+	default:
+		klogr.New().WithName("logger").Info("unknown log encoder, using console", "encoder", l.Encoder)
+	}
+	return klogr.New()
+}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-workload-identity/pkg/webhook"
 
 	"github.com/gorilla/mux"
+	"k8s.io/klog/v2/klogr"
 )
 
 var (
@@ -62,7 +63,7 @@ func TestProxy_MSIHandler(t *testing.T) {
 			setup()
 			defer teardown()
 
-			p := &proxy{}
+			p := &proxy{logger: klogr.New()}
 			rtr.PathPrefix(tokenPathPrefix).HandlerFunc(p.msiHandler)
 			rtr.PathPrefix("/").HandlerFunc(p.defaultPathHandler)
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -80,7 +80,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	// explicitly set the namespace to request namespace
 	pod.Namespace = req.Namespace
 
-	logger := log.Log.WithName("handler").WithValues("pod", pod.Name, "namespace", pod.Namespace, "serviceAccount", pod.Spec.ServiceAccountName)
+	logger := log.Log.WithName("handler").WithValues("pod", pod.Name, "namespace", pod.Namespace, "service-account", pod.Spec.ServiceAccountName)
 	// get service account associated with the pod
 	serviceAccount := &corev1.ServiceAccount{}
 	if err = m.client.Get(ctx, types.NamespacedName{Name: pod.Spec.ServiceAccountName, Namespace: pod.Namespace}, serviceAccount); err != nil {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,4 +1,4 @@
-// +build e2e
+//go:build e2e
 
 package e2e
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,4 +1,4 @@
-// +build e2e
+//go:build e2e
 
 package e2e
 

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -1,4 +1,4 @@
-// +build e2e
+//go:build e2e
 
 package e2e
 

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -1,4 +1,4 @@
-// +build e2e
+//go:build e2e
 
 package e2e
 
@@ -19,7 +19,7 @@ import (
 
 // Only kind cluster supports custom service account issuer for now.
 // The proxy implementation is only for Linux.
-var _ = ginkgo.Describe("Proxy [KindOnly][LinuxOnly]", func() {
+var _ = ginkgo.Describe("Proxy [KindOnly] [LinuxOnly]", func() {
 	f := framework.NewDefaultFramework("proxy")
 
 	ginkgo.It("should get a valid AAD token with the proxy sidecar", func() {
@@ -68,6 +68,7 @@ var _ = ginkgo.Describe("Proxy [KindOnly][LinuxOnly]", func() {
 					Name:            proxy,
 					Image:           proxyImage,
 					ImagePullPolicy: corev1.PullIfNotPresent,
+					Args:            []string{"--log-encoder=json"},
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",

--- a/test/e2e/token_exchange.go
+++ b/test/e2e/token_exchange.go
@@ -1,4 +1,4 @@
-// +build e2e
+//go:build e2e
 
 package e2e
 

--- a/test/e2e/webhook.go
+++ b/test/e2e/webhook.go
@@ -1,4 +1,4 @@
-// +build e2e
+//go:build e2e
 
 package e2e
 

--- a/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
@@ -40,6 +40,7 @@ spec:
       containers:
       - args:
         - --arc-cluster={{ .Values.arcCluster }}
+        - --log-encoder={{ .Values.logEncoder }}
         command:
         - /manager
         envFrom:

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
@@ -46,6 +46,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | service.targetPort | Service target port                                                      | `9443`                                                  |
 | azureTenantID      | [**REQUIRED**] Azure tenant ID                                           | ``                                                      |
 | azureEnvironment   | Azure Environment                                                        | `AzurePublicCloud`                                      |
+| logEncoder         | The log encoder to use for the webhook manager (`json`, `console`)       | `console`                                               |
 
 ## Contributing Changes
 

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-labels: 
+labels:
   azure-workload-identity.io/system: "true"
 replicaCount: 2
 image:
@@ -28,3 +28,4 @@ service:
   targetPort: 9443
 azureEnvironment: AzurePublicCloud
 azureTenantID:
+logEncoder: console


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

- support console log encoding with `klogr`. 
- provide an option to choose between `console` and `json` log encoding through `--log-encoder`
- switch from `klog` to our logger wrapper for proxy
- use `klog.ErrorS` and `errors.Wrap` when possible

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
