### PR TITLE
chore: update debian-iptables to buster-v1.6.7

### DIFF
--- a/docker/init.Dockerfile
+++ b/docker/init.Dockerfile
@@ -1,7 +1,6 @@
-FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.6.6
+FROM k8s.gcr.io/build-image/debian-iptables:buster-v1.6.7
 
-# upgrading libssl1.1 due to CVE-2021-33910 and CVE-2021-3712
-RUN clean-install ca-certificates libssl1.1
+RUN clean-install ca-certificates
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Update debian-iptables to buster-v1.6.7.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
