### PR TITLE
fix: make proxy port configurable in init-iptables.sh

### DIFF
--- a/docker/proxy.Dockerfile
+++ b/docker/proxy.Dockerfile
@@ -25,4 +25,3 @@ COPY --from=builder /workspace/proxy .
 USER nonroot:nonroot
 
 ENTRYPOINT [ "/proxy" ]
-EXPOSE 8000

--- a/examples/migration/pod-with-proxy-init-and-proxy-sidecar.yaml
+++ b/examples/migration/pod-with-proxy-init-and-proxy-sidecar.yaml
@@ -15,6 +15,9 @@ spec:
         add:
         - NET_ADMIN
       privileged: true
+    env:
+    - name: PROXY_PORT
+      value: "8000"
   containers:
   - name: nginx
     image: nginx:alpine

--- a/init/init-iptables.sh
+++ b/init/init-iptables.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-# Forward outbound traffic for 169.254.169.254:80 to proxy
-iptables -t nat -A OUTPUT -p tcp -d 169.254.169.254 --dport 80 -j REDIRECT --to-port 8000
+PROXY_PORT=${PROXY_PORT:-8000}
+METADATA_IP=${METADATA_IP:-169.254.169.254}
+METADATA_PORT=${METADATA_PORT:-80}
 
-# List all iptables rules.
+# Forward outbound traffic for metadata endpoint to proxy
+iptables -t nat -A OUTPUT -p tcp -d "${METADATA_IP}" --dport "${METADATA_PORT}" -j REDIRECT --to-port "${PROXY_PORT}"
+
+# List all iptables rules
 iptables -t nat --list

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -53,6 +53,12 @@ var _ = ginkgo.Describe("Proxy [KindOnly][LinuxOnly]", func() {
 						Add: []corev1.Capability{"NET_ADMIN"},
 					},
 				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "PROXY_PORT",
+						Value: "8000",
+					},
+				},
 			},
 		}
 
@@ -65,7 +71,7 @@ var _ = ginkgo.Describe("Proxy [KindOnly][LinuxOnly]", func() {
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",
-							ContainerPort: 8080,
+							ContainerPort: 8000,
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
Makes the proxy port, metadata IP and metadata port configurable in the proxy-init script using `PROXY_PORT`, `METADATA_IP`, `METADATA_PORT`.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/177

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
