### PR TITLE
feat: add arm64 support to images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ docs/book/book/
 
 # logs
 _artifacts/
+
+# Makefile output
+.image-*

--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -46,10 +46,14 @@ jobs:
           SKIP_PREFLIGHT: "true"
           SERVICE_ACCOUNT_ISSUER: $(SERVICE_ACCOUNT_ISSUER)
       - script: |
-          make docker-build-webhook
+          make docker-build
           KIND=$(pwd)/hack/tools/bin/kind
           ${KIND} load docker-image ${REGISTRY}/webhook:${IMAGE_VERSION} --name azure-workload-identity
         displayName: Build the webhook image
+        env:
+          ALL_IMAGES: webhook
+          ALL_LINUX_ARCH: amd64
+          OUTPUT_TYPE: type=docker
       - script: |
           set -o errexit
           sed -i "s/AZURE_TENANT_ID: .*/AZURE_TENANT_ID: ${AZURE_TENANT_ID}/" manifest_staging/deploy/azure-wi-webhook.yaml

--- a/.pipelines/templates/publish-images.yaml
+++ b/.pipelines/templates/publish-images.yaml
@@ -20,14 +20,17 @@ steps:
     displayName: export environment variables
   - script: make docker-build
     displayName: make docker-build
+    env:
+      ALL_LINUX_ARCH: amd64 # build amd64 only to speed up PR gate
+      OUTPUT_TYPE: type=docker
   - script: |
       wget https://github.com/aquasecurity/trivy/releases/download/v0.18.3/trivy_0.18.3_Linux-64bit.tar.gz
       tar zxvf trivy_0.18.3_Linux-64bit.tar.gz
       # show all vulnerabilities in the logs
       ./trivy image --reset
       for IMAGE_NAME in "proxy" "proxy-init" "webhook"; do
-        ./trivy "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}"
-        ./trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}" || exit 1
+        ./trivy "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-linux-amd64"
+        ./trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-linux-amd64" || exit 1
       done
     displayName: Scan images
   - script: |
@@ -38,6 +41,14 @@ steps:
       DOCKER_PASSWORD: $(DOCKER_PASSWORD)
     condition: and(succeeded(), eq(${{ parameters.publish }}, true))
     displayName: docker login
-  - script: make docker-push
+  - script: |
+      # build arm64 before building the manifest
+      OUTPUT_TYPE=type=docker ALL_LINUX_ARCH=arm64 make docker-build
+      for IMAGE_NAME in "proxy" "proxy-init" "webhook"; do
+        for OS_ARCH in "linux-amd64" "linux-arm64"; do
+          docker push "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-${OS_ARCH}"
+        done
+      done
+      make docker-push-manifest
     condition: and(succeeded(), eq(${{ parameters.publish }}, true))
-    displayName: make docker-push
+    displayName: make docker-push-manifest

--- a/.pipelines/templates/upgrade.yaml
+++ b/.pipelines/templates/upgrade.yaml
@@ -35,8 +35,6 @@ jobs:
         displayName: Upgrade cluster
       - script: make test-e2e
         displayName: Webhook E2E test suite
-        env:
-          SKIP_IMAGE_BUILD: "true"
       - script: az group delete --name "${CLUSTER_NAME}" --yes --no-wait || true
         displayName: Cleanup
         condition: always()

--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/build-image/debian-iptables:bullseye-v1.0.0
+FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-iptables:bullseye-v1.0.0
 
 # upgrading libssl1.1 due to CVE-2021-3711
 RUN clean-install ca-certificates libssl1.1

--- a/docker/proxy.Dockerfile
+++ b/docker/proxy.Dockerfile
@@ -15,11 +15,12 @@ COPY cmd/proxy/main.go main.go
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "${LDFLAGS:--X github.com/Azure/azure-workload-identity/pkg/version.BuildVersion=latest}" -o proxy main.go
+ARG GOARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS:--X github.com/Azure/azure-workload-identity/pkg/version.BuildVersion=latest}" -o proxy main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETPLATFORM:-linux/amd64} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/proxy .
 USER nonroot:nonroot

--- a/docker/webhook.Dockerfile
+++ b/docker/webhook.Dockerfile
@@ -16,11 +16,12 @@ COPY cmd/webhook/main.go main.go
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "${LDFLAGS:--X github.com/Azure/azure-workload-identity/pkg/version.BuildVersion=latest}" -o manager main.go
+ARG GOARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS:--X github.com/Azure/azure-workload-identity/pkg/version.BuildVersion=latest}" -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETPLATFORM:-linux/amd64} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/docs/book/src/development.md
+++ b/docs/book/src/development.md
@@ -218,7 +218,7 @@ azure-workload-identity-control-plane   Ready    control-plane,master   2m28s   
 export REGISTRY=<YourPublicRegistry>
 export IMAGE_VERSION="$(git describe --tags --always)"
 export AZURE_TENANT_ID="..."
-make docker-build-webhook deploy
+ALL_IMAGES=webhook make clean docker-build docker-push-manifest deploy
 ```
 
 ## Unit Test

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -20,7 +20,8 @@ create_cluster() {
     download_service_account_keys
     # create a kind cluster, then build and load the webhook manager image to the kind cluster
     make kind-create
-    [[ "${SKIP_IMAGE_BUILD:-}" == "true" ]] || OUTPUT_TYPE="type=docker" make docker-build-webhook docker-build-e2e-msal-go docker-build-proxy docker-build-init
+    # only build amd64 images for now
+    OUTPUT_TYPE="type=docker" ALL_LINUX_ARCH="amd64" make docker-build docker-build-e2e-msal-go
     make kind-load-image
   else
     : "${REGISTRY:?Environment variable empty or not defined.}"
@@ -48,7 +49,8 @@ create_cluster() {
     fi
 
     echo "Building controller and deploying webhook to the cluster"
-    [[ "${SKIP_IMAGE_BUILD:-}" == "true" ]] || make docker-build-webhook
+    # only build webhook since AKS clusters don't have support for proxy and proxy init
+    ALL_IMAGES=webhook make docker-build docker-push-manifest
   fi
   ${KUBECTL} get nodes -owide
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

Add arm64 support to webhook, proxy, and proxy-int image.

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #186 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
