### PR TITLE
chore: use numeric user in Dockerfile & parameterize trivy version

### DIFF
--- a/.pipelines/publish.yaml
+++ b/.pipelines/publish.yaml
@@ -7,7 +7,7 @@ pool: staging-pool
 
 jobs:
   - job: publish
-    timeoutInMinutes: 10
+    timeoutInMinutes: 30
     workspace:
       clean: all
     steps:

--- a/.pipelines/templates/publish-images.yaml
+++ b/.pipelines/templates/publish-images.yaml
@@ -24,8 +24,8 @@ steps:
       ALL_LINUX_ARCH: amd64 # build amd64 only to speed up PR gate
       OUTPUT_TYPE: type=docker
   - script: |
-      wget https://github.com/aquasecurity/trivy/releases/download/v0.18.3/trivy_0.18.3_Linux-64bit.tar.gz
-      tar zxvf trivy_0.18.3_Linux-64bit.tar.gz
+      wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION:-0.20.0}/trivy_${TRIVY_VERSION:-0.20.0}_Linux-64bit.tar.gz
+      tar zxvf trivy_${TRIVY_VERSION:-0.20.0}_Linux-64bit.tar.gz
       # show all vulnerabilities in the logs
       ./trivy image --reset
       for IMAGE_NAME in "proxy" "proxy-init" "webhook"; do
@@ -33,6 +33,8 @@ steps:
         ./trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-linux-amd64" || exit 1
       done
     displayName: Scan images
+    env:
+      TRIVY_VERSION: $(TRIVY_VERSION)
   - script: |
       if [[ "${REGISTRY}" =~ ghcr.io.* ]]; then
         echo "${DOCKER_PASSWORD}" | docker login ghcr.io -u azure --password-stdin

--- a/Makefile
+++ b/Makefile
@@ -243,11 +243,13 @@ $(HELM):
 ## --------------------------------------
 ## E2E images
 ## --------------------------------------
-MSAL_GO_E2E_IMAGE := $(REGISTRY)/msal-go-e2e:$(IMAGE_VERSION)
+MSAL_GO_E2E_IMAGE_NAME := msal-go-e2e
+MSAL_GO_E2E_IMAGE := $(REGISTRY)/$(MSAL_GO_E2E_IMAGE_NAME):$(IMAGE_VERSION)
 
 .PHONY: docker-build-e2e-msal-go
 docker-build-e2e-msal-go:
 	docker buildx build --no-cache -t $(MSAL_GO_E2E_IMAGE) -f examples/msal-go/Dockerfile --platform="linux/amd64" --output=$(OUTPUT_TYPE) examples/msal-go
+	touch .image-$(MSAL_GO_E2E_IMAGE_NAME)-amd64
 
 ## --------------------------------------
 ## Testing
@@ -307,12 +309,12 @@ KIND_CLUSTER_NAME ?= azure-workload-identity
 kind-create: $(KIND) $(KUBECTL)
 	./scripts/create-kind-cluster.sh
 
-.PHONY: kind-load-image
-kind-load-image:
-	$(KIND) load docker-image $(WEBHOOK_IMAGE) --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image $(MSAL_GO_E2E_IMAGE) --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image $(PROXY_IMAGE) --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image $(INIT_IMAGE) --name $(KIND_CLUSTER_NAME)
+.PHONY: kind-load-images
+kind-load-images:
+	-[ -f .image-$(WEBHOOK_IMAGE_NAME)-amd64 ] && $(KIND) load docker-image $(WEBHOOK_IMAGE) --name $(KIND_CLUSTER_NAME)
+	-[ -f .image-$(PROXY_IMAGE_NAME)-amd64 ] && $(KIND) load docker-image $(PROXY_IMAGE) --name $(KIND_CLUSTER_NAME)
+	-[ -f .image-$(INIT_IMAGE_NAME)-amd64 ] && $(KIND) load docker-image $(INIT_IMAGE) --name $(KIND_CLUSTER_NAME)
+	-[ -f .image-$(MSAL_GO_E2E_IMAGE_NAME)-amd64 ] && $(KIND) load docker-image $(MSAL_GO_E2E_IMAGE) --name $(KIND_CLUSTER_NAME)
 
 .PHONY: kind-delete
 kind-delete: $(KIND)

--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -4,5 +4,7 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-ipt
 RUN clean-install ca-certificates libssl1.1
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh
+# Kubernetes runAsNonRoot requires USER to be numeric
+USER 65532:65532
 
 ENTRYPOINT ["./bin/init-iptables.sh"]

--- a/docker/proxy.Dockerfile
+++ b/docker/proxy.Dockerfile
@@ -23,6 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflag
 FROM --platform=${TARGETPLATFORM:-linux/amd64} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/proxy .
-USER nonroot:nonroot
+# Kubernetes runAsNonRoot requires USER to be numeric
+USER 65532:65532
 
 ENTRYPOINT [ "/proxy" ]

--- a/docker/webhook.Dockerfile
+++ b/docker/webhook.Dockerfile
@@ -24,6 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflag
 FROM --platform=${TARGETPLATFORM:-linux/amd64} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+# Kubernetes runAsNonRoot requires USER to be numeric
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/examples/migration/pod-with-proxy-init-and-proxy-sidecar.yaml
+++ b/examples/migration/pod-with-proxy-init-and-proxy-sidecar.yaml
@@ -5,16 +5,18 @@ metadata:
   labels:
     app: httpbin
 spec:
-  serviceAccountName: old-sa
+  serviceAccountName: workload-identity-sa
   initContainers:
   - name: init-networking
-    image: mcr.microsoft.com/oss/azure/workload-identity/proxy-init:v0.4.0
-    imagePullPolicy: Always
+    image: mcr.microsoft.com/oss/azure/workload-identity/proxy-init:v0.5.0
     securityContext:
       capabilities:
         add:
         - NET_ADMIN
+        drop:
+        - ALL
       privileged: true
+      runAsUser: 0
     env:
     - name: PROXY_PORT
       value: "8000"
@@ -24,7 +26,6 @@ spec:
     ports:
     - containerPort: 80
   - name: proxy
-    image: mcr.microsoft.com/oss/azure/workload-identity/proxy:v0.4.0
-    imagePullPolicy: Always
+    image: mcr.microsoft.com/oss/azure/workload-identity/proxy:v0.5.0
     ports:
     - containerPort: 8000

--- a/examples/msal-go/Dockerfile
+++ b/examples/msal-go/Dockerfile
@@ -20,6 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o msalgo .
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/msalgo .
-USER nonroot:nonroot
+# Kubernetes runAsNonRoot requires USER to be numeric
+USER 65532:65532
 
 ENTRYPOINT ["/msalgo"]

--- a/examples/msal-net/akvdotnet/windows.Dockerfile
+++ b/examples/msal-net/akvdotnet/windows.Dockerfile
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/dotnet/runtime:5.0-nanoserver-1809
 WORKDIR /app
 COPY ./bin/release/netcoreapp5.0/publish/ .
-
+# Kubernetes runAsNonRoot requires USER to be numeric
+USER 65532:65532
 ENTRYPOINT ["dotnet", "akvdotnet.dll"]

--- a/examples/msal-node/Dockerfile
+++ b/examples/msal-node/Dockerfile
@@ -8,4 +8,6 @@ RUN npm install
 FROM gcr.io/distroless/nodejs:14
 COPY --from=build-env /app /app
 WORKDIR /app
+# Kubernetes runAsNonRoot requires USER to be numeric
+USER 65532:65532
 CMD ["index.js"]

--- a/examples/msal-python/Dockerfile
+++ b/examples/msal-python/Dockerfile
@@ -16,4 +16,6 @@ FROM gcr.io/distroless/python3-debian10
 COPY --from=build-venv /venv /venv
 COPY . /app
 WORKDIR /app
+# Kubernetes runAsNonRoot requires USER to be numeric
+USER 65532:65532
 ENTRYPOINT ["/venv/bin/python3", "main.py"]

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -22,7 +22,7 @@ create_cluster() {
     make kind-create
     # only build amd64 images for now
     OUTPUT_TYPE="type=docker" ALL_LINUX_ARCH="amd64" make docker-build docker-build-e2e-msal-go
-    make kind-load-image
+    make kind-load-images
   else
     : "${REGISTRY:?Environment variable empty or not defined.}"
 
@@ -82,7 +82,7 @@ main() {
   az login -i > /dev/null && echo "Using machine identity for az commands" || echo "Using pre-existing credential for az commands"
 
   create_cluster
-  make clean deploy
+  make deploy
   poll_webhook_readiness
 
   if [[ -n "${WINDOWS_NODE_NAME:-}" ]]; then

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -42,6 +42,8 @@ var _ = ginkgo.Describe("Proxy [KindOnly] [LinuxOnly]", func() {
 		)
 
 		trueVal := true
+		// proxy-init needs to be run as root
+		runAsRoot := int64(0)
 		pod.Spec.InitContainers = []corev1.Container{
 			{
 				Name:            proxyInit,
@@ -49,8 +51,10 @@ var _ = ginkgo.Describe("Proxy [KindOnly] [LinuxOnly]", func() {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				SecurityContext: &corev1.SecurityContext{
 					Privileged: &trueVal,
+					RunAsUser:  &runAsRoot,
 					Capabilities: &corev1.Capabilities{
-						Add: []corev1.Capability{"NET_ADMIN"},
+						Add:  []corev1.Capability{"NET_ADMIN"},
+						Drop: []corev1.Capability{"ALL"},
 					},
 				},
 				Env: []corev1.EnvVar{


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

- Use numeric user in Dockerfile so containers can be run as non-root
- parameterize trivy version
- bump image publishing timeout from 10 to 30 minutes

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #192 
Fixes #193

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
