### PR TITLE
chore: include azwi as part of GitHub releases

### DIFF
--- a/.github/workflows/create-tag.yaml
+++ b/.github/workflows/create-tag.yaml
@@ -27,9 +27,18 @@ jobs:
           git tag ${{ steps.get-tag.outputs.tag }}
           go install github.com/git-chglog/git-chglog/cmd/git-chglog@v0.15.0
           git-chglog ${{ steps.get-tag.outputs.tag }} > CHANGELOG.md
+      - name: Build azwi-cli
+        run: |
+          make clean
+          for os_arch_extension in linux-amd64 linux-arm64 darwin-amd64 windows-amd64-exe; do
+            GOOS="$(echo ${os_arch_extension} | cut -d '-' -f 1)" \
+            GOARCH="$(echo ${os_arch_extension} | cut -d '-' -f 2)" \
+              make bin/azwi-${os_arch_extension/-exe/.exe}
+          done
+          find ./bin -type f -name 'azwi-*' | sort | xargs sha256sum >> ./bin/sha256sums.txt
       - uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.get-tag.outputs.tag }}
           bodyFile: CHANGELOG.md
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "deploy/*.yaml"
+          artifacts: "deploy/*.yaml,bin/*"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMAGE_VERSION ?= v0.5.0
 ORG_PATH := github.com/Azure
 PROJECT_NAME := azure-workload-identity
 BUILD_COMMIT := $(shell git rev-parse --short HEAD)
-REPO_PATH := "$(ORG_PATH)/$(PROJECT_NAME)"
+REPO_PATH := $(ORG_PATH)/$(PROJECT_NAME)
 
 # build variables
 BUILD_TIMESTAMP := $$(date +%Y-%m-%d-%H:%M)
@@ -20,8 +20,8 @@ PROXY_IMAGE := $(REGISTRY)/$(PROXY_IMAGE_NAME):$(IMAGE_VERSION)
 INIT_IMAGE := $(REGISTRY)/$(INIT_IMAGE_NAME):$(IMAGE_VERSION)
 WEBHOOK_IMAGE := $(REGISTRY)/$(WEBHOOK_IMAGE_NAME):$(IMAGE_VERSION)
 
-GOOS := $(shell go env GOOS)
-GOARCH :=$(shell go env GOARCH)
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
 
 # Directories
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
@@ -81,8 +81,20 @@ GO_INSTALL := ./hack/go-install.sh
 ## --------------------------------------
 
 .PHONY: azwi
-azwi:
-	go build -o $(BIN_DIR)/azwi -ldflags $(LDFLAGS) ./cmd/azwi
+azwi: bin/azwi-$(GOOS)-$(GOARCH)$(EXTENSION)
+	mv bin/azwi-$(GOOS)-$(GOARCH)$(EXTENSION) bin/azwi
+
+## --------------------------------------
+## Release Binaries
+## --------------------------------------
+
+EXTENSION.linux :=
+EXTENSION.darwin :=
+EXTENSION.windows := .exe
+EXTENSION := $(EXTENSION.$(GOOS))
+
+bin/azwi-$(GOOS)-$(GOARCH)$(EXTENSION):
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(BIN_DIR)/azwi-$(GOOS)-$(GOARCH)$(EXTENSION) -ldflags $(LDFLAGS) ./cmd/azwi
 
 ## --------------------------------------
 ## Images


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Build azwi-cli in linux/amd64, linux/arm64, darwin/amd64, and windows/amd64 and publish them as release artifacts.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #196

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
