### PR TITLE
feat: add `azwi jwks` to generate jwks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/ini.v1 v1.51.0
+	gopkg.in/square/go-jose.v2 v2.2.2
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v0.21.2

--- a/go.sum
+++ b/go.sum
@@ -1023,6 +1023,7 @@ gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mcuadros/go-syslog.v2 v2.2.1/go.mod h1:l5LPIyOOyIdQquNg+oU6Z3524YwrcqEm0aKH+5zpt2U=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/square/go-jose.v2 v2.2.2 h1:orlkJ3myw8CN1nVQHBFfloD+L3egixIa4FvUP6RosSA=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/pkg/cmd/jwks/root.go
+++ b/pkg/cmd/jwks/root.go
@@ -1,0 +1,202 @@
+package jwks
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	jose "gopkg.in/square/go-jose.v2"
+	"k8s.io/client-go/util/keyutil"
+)
+
+type jwksCmd struct {
+	publicKeys []string
+	outputFile string
+}
+
+// NewJWKSCmd returns a new serviceaccount command
+func NewJWKSCmd() *cobra.Command {
+	jwksCmd := &jwksCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "jwks",
+		Short: "JSON Web Key Sets for the service account issuer keys",
+		Long:  "This command provides the ability to generate a JSON Web Key Sets (JWKS) for the service account issuer keys",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return jwksCmd.validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return jwksCmd.run()
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringSliceVar(&jwksCmd.publicKeys, "public-keys", nil, "List of public keys to include in the JWKS")
+	f.StringVar(&jwksCmd.outputFile, "output-file", "", "The name of the file to write the JWKS to. If not provided, the default output is stdout")
+
+	_ = cmd.MarkFlagRequired("public-keys")
+
+	return cmd
+}
+
+func (jc *jwksCmd) validate() error {
+	if len(jc.publicKeys) == 0 {
+		return errors.New("no public keys provided")
+	}
+	return nil
+}
+
+func (jc *jwksCmd) run() error {
+	log.Debugf("generating JSON Web Key Set for public keys: %v", jc.publicKeys)
+
+	var pubKeys []interface{}
+	for _, file := range jc.publicKeys {
+		pubKey, err := keyutil.PublicKeysFromFile(file)
+		if err != nil {
+			return errors.Wrap(err, "failed to read public key file")
+		}
+		pubKeys = append(pubKeys, pubKey...)
+	}
+
+	keySet, err := publicJWKSFromKeys(pubKeys)
+	if err != nil {
+		return errors.Wrap(err, "failed to construct JSONWebKeySet from a list of keys")
+	}
+	keysetJSON, err := json.MarshalIndent(keySet, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal JSONWebKeySet")
+	}
+
+	if jc.outputFile != "" {
+		// write the keyset to the file
+		if err = os.WriteFile(jc.outputFile, keysetJSON, 0600); err != nil {
+			return errors.Wrap(err, "failed to write JWKS to file")
+		}
+		log.Debugf("wrote JWKS to file: %v", jc.outputFile)
+		return nil
+	}
+
+	log.Debugf("writing JWKS to stdout")
+	// write the keyset to stdout
+	if _, err = os.Stdout.Write(keysetJSON); err != nil {
+		return errors.Wrap(err, "failed to write JWKS to stdout")
+	}
+	return nil
+}
+
+// Most of the changes here have been vendored from pkg/serviceaccount/openidmetadata.go
+//  * link: https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/pkg/serviceaccount/openidmetadata.go
+
+type publicKeyGetter interface {
+	Public() crypto.PublicKey
+}
+
+// publicJWKSFromKeys constructs a JSONWebKeySet from a list of keys. The key
+// set will only contain the public keys associated with the input keys.
+func publicJWKSFromKeys(in []interface{}) (*jose.JSONWebKeySet, error) {
+	// Decode keys into a JWKS.
+	var keys jose.JSONWebKeySet
+	for _, key := range in {
+		var pubkey *jose.JSONWebKey
+		var err error
+
+		switch k := key.(type) {
+		case publicKeyGetter:
+			// This is a private key. Get its public key
+			pubkey, err = jwkFromPublicKey(k.Public())
+		default:
+			pubkey, err = jwkFromPublicKey(k)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if !pubkey.Valid() {
+			return nil, errors.New("the public key is not valid")
+		}
+		keys.Keys = append(keys.Keys, *pubkey)
+	}
+	return &keys, nil
+}
+
+func jwkFromPublicKey(publicKey crypto.PublicKey) (*jose.JSONWebKey, error) {
+	alg, err := algorithmFromPublicKey(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	keyID, err := keyIDFromPublicKey(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	jwk := &jose.JSONWebKey{
+		Algorithm: string(alg),
+		Key:       publicKey,
+		KeyID:     keyID,
+		Use:       "sig",
+	}
+
+	if !jwk.IsPublic() {
+		return nil, errors.Errorf("JWK was not a public key! JWK: %v", jwk)
+	}
+
+	return jwk, nil
+}
+
+func algorithmFromPublicKey(publicKey crypto.PublicKey) (jose.SignatureAlgorithm, error) {
+	switch pk := publicKey.(type) {
+	case *rsa.PublicKey:
+		// IMPORTANT: If this function is updated to support additional key sizes,
+		// signerFromRSAPrivateKey in serviceaccount/jwt.go must also be
+		// updated to support the same key sizes. Today we only support RS256.
+		return jose.RS256, nil
+	case *ecdsa.PublicKey:
+		switch pk.Curve {
+		case elliptic.P256():
+			return jose.ES256, nil
+		case elliptic.P384():
+			return jose.ES384, nil
+		case elliptic.P521():
+			return jose.ES512, nil
+		default:
+			return "", errors.New("unknown private key curve, must be 256, 384, or 521")
+		}
+	case jose.OpaqueSigner:
+		return jose.SignatureAlgorithm(pk.Public().Algorithm), nil
+	default:
+		return "", errors.New("unknown public key type, must be *rsa.PublicKey, *ecdsa.PublicKey, or jose.OpaqueSigner")
+	}
+}
+
+// keyIDFromPublicKey derives a key ID non-reversibly from a public key.
+//
+// The Key ID is field on a given on JWTs and JWKs that help relying parties
+// pick the correct key for verification when the identity party advertises
+// multiple keys.
+//
+// Making the derivation non-reversible makes it impossible for someone to
+// accidentally obtain the real key from the key ID and use it for token
+// validation.
+func keyIDFromPublicKey(publicKey interface{}) (string, error) {
+	publicKeyDERBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to serialize public key to DER format")
+	}
+
+	hasher := crypto.SHA256.New()
+	hasher.Write(publicKeyDERBytes)
+	publicKeyDERHash := hasher.Sum(nil)
+
+	keyID := base64.RawURLEncoding.EncodeToString(publicKeyDERHash)
+
+	return keyID, nil
+}

--- a/pkg/cmd/jwks/root_test.go
+++ b/pkg/cmd/jwks/root_test.go
@@ -1,0 +1,146 @@
+package jwks
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestJWKSCmdValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		jwksCmd *jwksCmd
+		verify  func(t *testing.T, err error)
+	}{
+		{
+			name:    "no public keys",
+			jwksCmd: &jwksCmd{},
+			verify: func(t *testing.T, err error) {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			},
+		},
+		{
+			name: "valid command",
+			jwksCmd: &jwksCmd{
+				publicKeys: []string{"testdata/public.key"},
+			},
+			verify: func(t *testing.T, err error) {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.verify(t, tt.jwksCmd.validate())
+		})
+	}
+}
+
+func TestJWKSCmdRun(t *testing.T) {
+	testPublicKey := `
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1QJE2YmLbvMLP6FtzcfP
+zGbSDbHEEtA0mH6kwgrOrlKs83zj2vr6Y5k/ZcGdIbsdm5vDj2IxtSkE+pSDtgFM
+2iq0sJ7xuE6RYmlrtBm+H2WHvXrP9RrG1EfO7iWs6Czj4A/Ddxg3kNUiQCtQEJww
+H2pfrUkh8STQhST/T86pq5AIFCuQiQSrkfC80eD9bUFypV3CLB2M9Fa1hbvOWbzS
+F93/I0toUK2+oPgVW6m2EwMyy8Fh/3KRixrAJO8g+D4d537C1fa1vJJRlMRFtLMA
+/bo6k1fAtNsVQuQoML5CmRrvNT7ZpXRLaQy64OSFrVLD3Pb7wct7b4g2xQECixQo
+dwIDAQAB
+-----END PUBLIC KEY-----`
+
+	expectedJWKS := `
+{
+  "keys": [
+		{
+		"use": "sig",
+		"kty": "RSA",
+		"kid": "2A3FPpix2keOV1SGPQiM0_wVemz4XOIgQyJJnpu5sPE",
+		"alg": "RS256",
+		"n": "1QJE2YmLbvMLP6FtzcfPzGbSDbHEEtA0mH6kwgrOrlKs83zj2vr6Y5k_ZcGdIbsdm5vDj2IxtSkE-pSDtgFM2iq0sJ7xuE6RYmlrtBm-H2WHvXrP9RrG1EfO7iWs6Czj4A_Ddxg3kNUiQCtQEJwwH2pfrUkh8STQhST_T86pq5AIFCuQiQSrkfC80eD9bUFypV3CLB2M9Fa1hbvOWbzSF93_I0toUK2-oPgVW6m2EwMyy8Fh_3KRixrAJO8g-D4d537C1fa1vJJRlMRFtLMA_bo6k1fAtNsVQuQoML5CmRrvNT7ZpXRLaQy64OSFrVLD3Pb7wct7b4g2xQECixQodw",
+		"e": "AQAB"
+		}
+	]
+}`
+
+	tmpDir, err := os.MkdirTemp("", "jwks")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	publicKeyFile := filepath.Join(tmpDir, "public.key")
+	expectedOutputFile := filepath.Join(tmpDir, "jwks.json")
+
+	if err = os.WriteFile(publicKeyFile, []byte(testPublicKey), 0600); err != nil {
+		t.Errorf("Error writing file: %v", err)
+	}
+
+	jwksCmd := &jwksCmd{
+		publicKeys: []string{publicKeyFile},
+		outputFile: expectedOutputFile,
+	}
+	if err = jwksCmd.run(); err != nil {
+		t.Errorf("Error running jwksCmd: %v", err)
+	}
+
+	if _, err := os.Stat(expectedOutputFile); os.IsNotExist(err) {
+		t.Errorf("Error creating jwks.json file: %v", err)
+	}
+	body, err := os.ReadFile(expectedOutputFile)
+	if err != nil {
+		t.Errorf("Error reading jwks.json file: %v", err)
+	}
+
+	var o1, o2 interface{}
+	if err := json.Unmarshal(body, &o1); err != nil {
+		t.Errorf("Error unmarshalling jwks.json: %v", err)
+	}
+	if err := json.Unmarshal([]byte(expectedJWKS), &o2); err != nil {
+		t.Errorf("Error unmarshalling expected jwks.json: %v", err)
+	}
+	if !reflect.DeepEqual(o1, o2) {
+		t.Errorf("expected jwks: %v, got: %v", o2, o1)
+	}
+
+	// Test jwks is written to stdout
+	jwksCmd.outputFile = ""
+
+	old := os.Stdout // keep backup of the real stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = jwksCmd.run()
+
+	outC := make(chan string)
+	// copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		outC <- strings.TrimSpace(buf.String())
+	}()
+
+	// back to normal state
+	w.Close()
+	os.Stdout = old // restoring the real stdout
+	out := <-outC
+
+	if err != nil {
+		t.Errorf("Error running jwksCmd: %v", err)
+	}
+	if err := json.Unmarshal([]byte(out), &o1); err != nil {
+		t.Errorf("Error unmarshalling jwks.json: %v", err)
+	}
+	if !reflect.DeepEqual(o1, o2) {
+		t.Errorf("expected jwks: %v, got: %v", o2, o1)
+	}
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/Azure/azure-workload-identity/pkg/cmd/jwks"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/version"
 
@@ -39,6 +40,7 @@ func NewRootCmd() *cobra.Command {
 
 	cmd.AddCommand(version.NewVersionCmd())
 	cmd.AddCommand(serviceaccount.NewServiceAccountCmd())
+	cmd.AddCommand(jwks.NewJWKSCmd())
 
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Add `azwi jwks` command to generate the JSON Web Key Set (JWKS) and write to file (if `--output-file` is provided) or stdout.

```console
➜ ./bin/azwi jwks -h
This command provides the ability to generate a JSON Web Key Sets (JWKS) for the service account issuer keys

Usage:
  azwi jwks [flags]

Flags:
  -h, --help                  help for jwks
      --output-file string    The name of the file to write the JWKS to. If not provided, the default output is stdout
      --public-keys strings   List of public keys to include in the JWKS

Global Flags:
      --debug   Enable debug logging
```

Usage:
```console
➜ ./bin/azwi jwks --public-keys /tmp/test.key | jq
{
  "keys": [
    {
      "use": "sig",
      "kty": "RSA",
      "kid": "2A3FPpix2keOV1SGPQiM0_wVemz4XOIgQyJJnpu5sPE",
      "alg": "RS256",
      "n": "1QJE2YmLbvMLP6FtzcfPzGbSDbHEEtA0mH6kwgrOrlKs83zj2vr6Y5k_ZcGdIbsdm5vDj2IxtSkE-pSDtgFM2iq0sJ7xuE6RYmlrtBm-H2WHvXrP9RrG1EfO7iWs6Czj4A_Ddxg3kNUiQCtQEJwwH2pfrUkh8STQhST_T86pq5AIFCuQiQSrkfC80eD9bUFypV3CLB2M9Fa1hbvOWbzSF93_I0toUK2-oPgVW6m2EwMyy8Fh_3KRixrAJO8g-D4d537C1fa1vJJRlMRFtLMA_bo6k1fAtNsVQuQoML5CmRrvNT7ZpXRLaQy64OSFrVLD3Pb7wct7b4g2xQECixQodw",
      "e": "AQAB"
    }
  ]
}

➜ ./bin/azwi jwks --public-keys /tmp/test.key --output-file test.json --debug
DEBU[0000] generating JSON Web Key Set for public keys: [/tmp/test.key]
DEBU[0000] wrote JWKS to file: test.json
```

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #189 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
