### PR TITLE
chore: release tarball in preparation to support homebrew

### DIFF
--- a/.github/workflows/create-tag.yaml
+++ b/.github/workflows/create-tag.yaml
@@ -29,16 +29,41 @@ jobs:
           git-chglog ${{ steps.get-tag.outputs.tag }} > CHANGELOG.md
       - name: Build azwi-cli
         run: |
+          build() {
+            export GOOS="$(echo ${1} | cut -d '-' -f 1)"
+            export GOARCH="$(echo ${1} | cut -d '-' -f 2)"
+
+            # in case of windows, we need to append .exe to the file name
+            EXTENSION="$(echo ${1} | cut -d '-' -f 3)"
+            EXTENSION=${EXTENSION/exe/.exe}
+
+            # build the binary
+            make bin/azwi-${GOOS}-${GOARCH}${EXTENSION}
+
+            # rename the binary to azwi
+            tmp_dir=$(mktemp -d)
+            cp bin/azwi-${GOOS}-${GOARCH}${EXTENSION} ${tmp_dir}/azwi${EXTENSION}
+
+            pushd ${tmp_dir}
+            tar -czf ${GITHUB_WORKSPACE}/_dist/azwi-${{ steps.get-tag.outputs.tag }}-${GOOS}-${GOARCH}.tar.gz azwi*
+            popd
+            rm -rf ${tmp_dir}
+          }
+
+          mkdir -p _dist
           make clean
-          for os_arch_extension in linux-amd64 linux-arm64 darwin-amd64 windows-amd64-exe; do
-            GOOS="$(echo ${os_arch_extension} | cut -d '-' -f 1)" \
-            GOARCH="$(echo ${os_arch_extension} | cut -d '-' -f 2)" \
-              make bin/azwi-${os_arch_extension/-exe/.exe}
+          for os_arch_extension in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 windows-amd64-exe; do
+            build ${os_arch_extension} &
           done
-          find ./bin -type f -name 'azwi-*' | sort | xargs sha256sum >> ./bin/sha256sums.txt
+          wait
+
+          pushd _dist
+          # consolidate tar and zip's sha256sum into a single file
+          find . -type f -name '*.tar.gz' | sort | xargs sha256sum >> sha256sums.txt
+          popd
       - uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.get-tag.outputs.tag }}
           bodyFile: CHANGELOG.md
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "deploy/*.yaml,bin/*"
+          artifacts: "deploy/*.yaml,_dist/*"

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 bin/
 hack/tools/bin/
 obj/
+_dist/
 sa.key
 sa.pub
 


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Follow-up for #198. Homebrew requires binaries to be packaged as tarballs.

Example release: https://github.com/chewong/azure-workload-identity/releases/tag/fix207

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

ref: #207 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
