### PR TITLE
ci: add semantic.yml and update release-manfiest make target

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,12 @@
+types:
+  - chore
+  - ci
+  - docs
+  - feat
+  - fix
+  - perf
+  - refactor
+  - release
+  - revert
+  - security
+  - test

--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,8 @@ release-manifest: $(KUSTOMIZE)
 	@sed -i -e "s/version: .*/version: $$(echo ${NEW_VERSION} | cut -c2-)/" ./third_party/open-policy-agent/gatekeeper/helmify/static/Chart.yaml
 	@sed -i -e "s/release: .*/release: ${NEW_VERSION}/" ./third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
 	@sed -i -e 's/Current release version: `.*`/Current release version: `'"${NEW_VERSION}"'`/' ./third_party/open-policy-agent/gatekeeper/helmify/static/README.md
+	@sed -i -e 's/proxy-init:.*/proxy-init:${NEW_VERSION}' ./examples/migration/pod-with-proxy-init-and-proxy-sidecar.yaml
+	@sed -i -e 's/proxy:.*/proxy:${NEW_VERSION}' ./examples/migration/pod-with-proxy-init-and-proxy-sidecar.yaml
 	export
 	$(MAKE) manifests
 


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

- Adding https://probot.github.io/apps/semantic-pull-requests/ as part of PR gate so `git-chglog` can properly generate a full changelog without missing PRs.
- Update `make release-manifest` to update proxy and proxy init version in `./examples/migration/pod-with-proxy-init-and-proxy-sidecar.yaml` during release.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
