### PR TITLE
fix: set default token expiration to 1h

### DIFF
--- a/docs/book/src/topics/azwi/serviceaccount-create.md
+++ b/docs/book/src/topics/azwi/serviceaccount-create.md
@@ -32,7 +32,7 @@ The "create" command executes the following phases in order:
           --service-account-issuer-url string           URL of the issuer
           --service-account-name string                 Name of the service account
           --service-account-namespace string            Namespace of the service account (default "default")
-          --service-account-token-expiration duration   Expiration time of the service account token. Must be between 1 hour and 24 hours (default 24h0m0s)
+          --service-account-token-expiration duration   Expiration time of the service account token. Must be between 1 hour and 24 hours (default 1h0m0s)
           --service-principal-name string               Name of the service principal that backs the AAD application. If this is not specified, the name of the AAD application will be used
           --service-principal-object-id string          Object ID of the service principal that backs the AAD application. If not specified, it will be fetched using the service principal name
           --skip-phases strings                         List of phases to skip

--- a/pkg/cmd/serviceaccount/phases/create/serviceaccount.go
+++ b/pkg/cmd/serviceaccount/phases/create/serviceaccount.go
@@ -46,11 +46,12 @@ func (p *serviceAccountPhase) prerun(data workflow.RunData) error {
 	}
 
 	minTokenExpirationDuration := time.Duration(webhook.MinServiceAccountTokenExpiration) * time.Second
+	maxTokenExpirationDuration := time.Duration(webhook.MaxServiceAccountTokenExpiration) * time.Second
 	if createData.ServiceAccountTokenExpiration() < minTokenExpirationDuration {
-		return errors.Errorf("--token-expiration must be greater than or equal to %s", minTokenExpirationDuration.String())
+		return errors.Errorf("--service-account-token-expiration must be greater than or equal to %s", minTokenExpirationDuration.String())
 	}
-	if createData.ServiceAccountTokenExpiration() > 24*time.Hour {
-		return errors.Errorf("--token-expiration must be less than or equal to 24h")
+	if createData.ServiceAccountTokenExpiration() > maxTokenExpirationDuration {
+		return errors.Errorf("--service-account-token-expiration must be less than or equal to %s", maxTokenExpirationDuration.String())
 	}
 
 	var err error

--- a/pkg/cmd/serviceaccount/phases/create/serviceaccount_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/serviceaccount_test.go
@@ -52,7 +52,7 @@ func TestServiceAccountPreRun(t *testing.T) {
 				serviceAccountName:            "test",
 				serviceAccountTokenExpiration: 1 * time.Minute,
 			},
-			errorMsg: "--token-expiration must be greater than or equal to 1h0m0s",
+			errorMsg: "--service-account-token-expiration must be greater than or equal to 1h0m0s",
 		},
 		{
 			name: "token expiration > maximum token expiration",
@@ -61,7 +61,7 @@ func TestServiceAccountPreRun(t *testing.T) {
 				serviceAccountName:            "test",
 				serviceAccountTokenExpiration: 25 * time.Hour,
 			},
-			errorMsg: "--token-expiration must be less than or equal to 24h",
+			errorMsg: "--service-account-token-expiration must be less than or equal to 24h0m0s",
 		},
 		{
 			name: "valid data",
@@ -95,7 +95,7 @@ func TestServiceAccountRun(t *testing.T) {
 	data := &mockCreateData{
 		serviceAccountNamespace:       "service-account-namespace",
 		serviceAccountName:            "service-account-name",
-		serviceAccountTokenExpiration: 1 * time.Hour,
+		serviceAccountTokenExpiration: 2 * time.Hour,
 		aadApplicationClientID:        "aad-application-client-id",
 		azureTenantID:                 "azure-tenant-id",
 		kubeClient:                    kubeClient,
@@ -122,7 +122,7 @@ func TestServiceAccountRun(t *testing.T) {
 	if sa.Annotations[webhook.TenantIDAnnotation] != "azure-tenant-id" {
 		t.Errorf("expected service account to have tenant id annotation but got: %s", sa.Annotations[webhook.TenantIDAnnotation])
 	}
-	if sa.Annotations[webhook.ServiceAccountTokenExpiryAnnotation] != "3600" {
+	if sa.Annotations[webhook.ServiceAccountTokenExpiryAnnotation] != "7200" {
 		t.Errorf("expected service account to have token expiration label but got: %s", sa.Labels[webhook.ServiceAccountTokenExpiryAnnotation])
 	}
 }

--- a/pkg/webhook/consts.go
+++ b/pkg/webhook/consts.go
@@ -16,10 +16,13 @@ const (
 	// By default, the projected service account token volume will be added to all containers if the service account is labeled with `azure.workload.identity/use: true`
 	SkipContainersAnnotation = "azure.workload.identity/skip-containers"
 
-	// DefaultServiceAccountTokenExpiration is the default service account token expiration in seconds
-	DefaultServiceAccountTokenExpiration = int64(86400)
 	// MinServiceAccountTokenExpiration is the minimum service account token expiration in seconds
 	MinServiceAccountTokenExpiration = int64(3600)
+	// MaxServiceAccountTokenExpiration is the maximum service account token expiration in seconds
+	MaxServiceAccountTokenExpiration = int64(86400)
+	// DefaultServiceAccountTokenExpiration is the default service account token expiration in seconds
+	// This is the Kubernetes default value for projected service account token
+	DefaultServiceAccountTokenExpiration = int64(3600)
 )
 
 // Environment variables injected in the pod

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -217,7 +217,7 @@ func getServiceAccountTokenExpiration(pod *corev1.Pod, sa *corev1.ServiceAccount
 }
 
 func validServiceAccountTokenExpiry(tokenExpiry int64) bool {
-	return tokenExpiry <= DefaultServiceAccountTokenExpiration && tokenExpiry >= MinServiceAccountTokenExpiration
+	return tokenExpiry <= MaxServiceAccountTokenExpiration && tokenExpiry >= MinServiceAccountTokenExpiration
 }
 
 // getClientID returns the clientID to be configured

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -112,7 +112,8 @@ test_helm_chart() {
     --create-namespace \
     --wait
   poll_webhook_readiness
-  make test-e2e-run
+  # TODO(aramase) remove the service account token expiration after v0.7.0 release
+  E2E_EXTRA_ARGS=-e2e.service-account-token-expiration=24h make test-e2e-run
 
   ${HELM} upgrade --install workload-identity-webhook "${REPO_ROOT}/manifest_staging/charts/workload-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/workload-identity/webhook}" \

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -25,10 +25,11 @@ import (
 )
 
 var (
-	arcCluster            bool
-	tokenExchangeE2EImage string
-	proxyInitImage        string
-	proxyImage            string
+	arcCluster                    bool
+	tokenExchangeE2EImage         string
+	proxyInitImage                string
+	proxyImage                    string
+	serviceAccountTokenExpiration time.Duration
 
 	c              *kubernetes.Clientset
 	coreNamespaces = []string{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -6,6 +6,9 @@ import (
 	"flag"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/Azure/azure-workload-identity/pkg/webhook"
 
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
@@ -16,6 +19,9 @@ func init() {
 	flag.StringVar(&tokenExchangeE2EImage, "e2e.token-exchange-image", "aramase/msal-go:v0.6.0", "The image to use for token exchange tests")
 	flag.StringVar(&proxyInitImage, "e2e.proxy-init-image", "mcr.microsoft.com/oss/azure/workload-identity/proxy-init:v0.6.0", "The proxy-init image")
 	flag.StringVar(&proxyImage, "e2e.proxy-image", "mcr.microsoft.com/oss/azure/workload-identity/proxy:v0.6.0", "The proxy image")
+	// This is only required because webhook v0.6.0 uses 86400 for default token expiration and we are running upgrade tests.
+	// TODO(aramase): remove this flag after v0.7.0 release
+	flag.DurationVar(&serviceAccountTokenExpiration, "e2e.service-account-token-expiration", time.Duration(webhook.DefaultServiceAccountTokenExpiration)*time.Second, "The service account token expiration")
 }
 
 // handleFlags sets up all flags and parses the command line.

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -312,7 +312,11 @@ func validateUnmutatedContainers(f *framework.Framework, pod *corev1.Pod, skipCo
 }
 
 func getVolumeProjectionSources(serviceAccountName string) []corev1.VolumeProjection {
-	expirationSeconds := webhook.DefaultServiceAccountTokenExpiration
+	// This is only required because webhook v0.6.0 uses 86400 for default token expiration
+	// and we are running upgrade tests.
+	// TODO(aramase): remove this after next release
+	expirationSeconds := int64(serviceAccountTokenExpiration.Seconds())
+
 	if arcCluster {
 		return []corev1.VolumeProjection{{
 			Secret: &corev1.SecretProjection{


### PR DESCRIPTION
The kubernetes default for projected service account token is 1h. Using
the same expiry value to be conformant. The minimum is 1h and max is
24h.

Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/245

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
