### PR TITLE
docs: allow `kubectl apply -f` through a URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,10 +200,6 @@ manifests: $(CONTROLLER_GEN) $(KUSTOMIZE)
 	$(KUSTOMIZE) build config/default -o manifest_staging/deploy/azure-wi-webhook.yaml
 	$(KUSTOMIZE) build third_party/open-policy-agent/gatekeeper/helmify | go run third_party/open-policy-agent/gatekeeper/helmify/*.go
 
-	@sed -i -e "s/AZURE_TENANT_ID: .*/AZURE_TENANT_ID: <replace with Azure Tenant ID>/" manifest_staging/deploy/azure-wi-webhook.yaml
-	@sed -i -e "s/AZURE_ENVIRONMENT: .*/AZURE_ENVIRONMENT: <replace with Azure Environment Name>/" manifest_staging/deploy/azure-wi-webhook.yaml
-	@sed -i -e "s/-arc-cluster=.*/-arc-cluster=false/" manifest_staging/deploy/azure-wi-webhook.yaml
-
 # Generate code
 .PHONY: generate
 generate: $(CONTROLLER_GEN) $(MOCKGEN) ## Runs Go related generate targets
@@ -394,7 +390,8 @@ release-manifest: $(KUSTOMIZE)
 	@sed -i -e 's/proxy:.*/proxy:${NEW_VERSION}/' ./examples/migration/pod-with-proxy-init-and-proxy-sidecar.yaml
 	@sed -i -e 's/proxy-init:[^"]*/proxy-init:${NEW_VERSION}/' ./test/e2e/e2e_test.go
 	@sed -i -e 's/proxy:[^"]*/proxy:${NEW_VERSION}/' ./test/e2e/e2e_test.go
-	export
+	@sed -i -e 's|download/v.*/azure-wi-webhook.yaml|download/${NEW_VERSION}/azure-wi-webhook.yaml|' ./docs/book/src/installation.md
+	@sed -i -e 's|azwi@v.*|azwi@${NEW_VERSION}|' ./docs/book/src/installation.md
 	$(MAKE) manifests
 
 .PHONY: promote-staging-manifest

--- a/docs/book/src/installation.md
+++ b/docs/book/src/installation.md
@@ -4,12 +4,10 @@
 
 ## Webhook
 
-Obtain your Azure tenant ID by running the following command:
+Export your Azure tenant ID as an environment variable by running the following command:
 
 ```bash
 export AZURE_TENANT_ID="$(az account show -s <AzureSubscriptionID> --query tenantId -otsv)"
-# TODO: account for different environments
-export AZURE_ENVIRONMENT="AzurePublicCloud"
 ```
 
 The tenant ID above will be the default tenant ID that the webhook uses when configuring the `AZURE_TENANT_ID` environment variable in the pod. In the case of a multi-tenant cluster, you can override the tenant ID by adding the `azure.workload.identity/tenant-id` annotation to your service account.
@@ -19,7 +17,6 @@ You can install the mutating webhook with one of the following methods:
 ### Helm
 
 ```bash
-# TODO(chewong): use https://azure.github.io/azure-workload-identity/charts
 helm install workload-identity-webhook manifest_staging/charts/workload-identity-webhook \
    --namespace azure-workload-identity-system \
    --create-namespace \
@@ -43,12 +40,14 @@ TEST SUITE: None
 
 ### Deployment YAML
 
-> Replace the Azure tenant ID and cloud environment name in [here][1] before executing
+#### Install `envsubst`
+
+The deployment YAML contains the environment variables we defined above and we rely on the `envsubst` binary to substitute them for their respective values before deploying. See [the `envsubst`'s installation guide][1] on how to install it.
+
+Install the webhook using the deployment YAML via `kubectl apply -f` and `envsubst`:
 
 ```bash
-sed -i "s/AZURE_TENANT_ID: .*/AZURE_TENANT_ID: ${AZURE_TENANT_ID}/" deploy/azure-wi-webhook.yaml
-sed -i "s/AZURE_ENVIRONMENT: .*/AZURE_ENVIRONMENT: ${AZURE_ENVIRONMENT}/" deploy/azure-wi-webhook.yaml
-kubectl apply -f deploy/azure-wi-webhook.yaml
+curl -s https://github.com/Azure/azure-workload-identity/releases/download/v0.6.0/azure-wi-webhook.yaml | envsubst | kubectl apply -f -
 ```
 
 <details>
@@ -72,18 +71,18 @@ mutatingwebhookconfiguration.admissionregistration.k8s.io/azure-wi-webhook-mutat
 
 ## [Azure Workload Identity CLI (`azwi`)][2]
 
-### go install
+### `go install`
 
 ```bash
-go install github.com/Azure/azure-workload-identity/cmd/azwi
+go install github.com/Azure/azure-workload-identity/cmd/azwi@v0.6.0
 ```
 
-### Homebrew (macOS only)
+### Homebrew (MacOS only)
 
 ```bash
 brew install Azure/azure-workload-identity/azwi
 ```
 
-[1]: https://github.com/Azure/azure-workload-identity/blob/1cb9d78159458b0c820c9c08fadf967833c8cdb4/deploy/azure-wi-webhook.yaml#L103-L104
+[1]: https://github.com/a8m/envsubst#installation
 
 [2]: ./topics/azwi.md

--- a/manifest_staging/deploy/azure-wi-webhook.yaml
+++ b/manifest_staging/deploy/azure-wi-webhook.yaml
@@ -100,8 +100,8 @@ subjects:
 ---
 apiVersion: v1
 data:
-  AZURE_ENVIRONMENT: <replace with Azure Environment Name>
-  AZURE_TENANT_ID: <replace with Azure Tenant ID>
+  AZURE_ENVIRONMENT: ${AZURE_ENVIRONMENT:-AzurePublicCloud}
+  AZURE_TENANT_ID: ${AZURE_TENANT_ID}
 kind: ConfigMap
 metadata:
   labels:
@@ -150,7 +150,7 @@ spec:
     spec:
       containers:
       - args:
-        - --arc-cluster=false
+        - --arc-cluster=${ARC_CLUSTER:-false}
         command:
         - /manager
         env:


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Allow `kubectl apply -f` through a URL.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #250

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
