### PR TITLE
fix: allow `make deploy` to deploy webhook using deployment YAML

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -14,13 +14,13 @@ pool: staging-pool
 
 jobs:
   - job: scan_images
-    timeoutInMinutes: 20
+    timeoutInMinutes: 30
     workspace:
       clean: all
     steps:
       - template: templates/scan-images.yaml
   - job: verify_deployment_yaml
-    timeoutInMinutes: 20
+    timeoutInMinutes: 30
     workspace:
       clean: all
     variables:
@@ -28,10 +28,6 @@ jobs:
       # - AZURE_TENANT_ID
       # - SERVICE_ACCOUNT_ISSUER
       - group: e2e-environment-variables
-      - name: REGISTRY
-        value: "e2e"
-      - name: IMAGE_VERSION
-        value: "latest"
       - name: OUTPUT_TYPE
         value: "type=docker"
     steps:
@@ -44,32 +40,27 @@ jobs:
           SKIP_PREFLIGHT: "true"
           SERVICE_ACCOUNT_ISSUER: $(SERVICE_ACCOUNT_ISSUER)
       - script: |
-          make docker-build
-          KIND=$(pwd)/hack/tools/bin/kind
-          ${KIND} load docker-image ${REGISTRY}/webhook:${IMAGE_VERSION} --name azure-workload-identity
+          # build the same image as the one in the deployment YAML
+          # then load it into the kind cluster
+          make docker-build kind-load-images
         displayName: Build the webhook image
         env:
           ALL_IMAGES: webhook
           ALL_LINUX_ARCH: amd64
           OUTPUT_TYPE: type=docker
       - script: |
-          set -o errexit
-          sed -i "s/AZURE_TENANT_ID: .*/AZURE_TENANT_ID: ${AZURE_TENANT_ID}/" manifest_staging/deploy/azure-wi-webhook.yaml
-          sed -i "s/AZURE_ENVIRONMENT: .*/AZURE_ENVIRONMENT: AzurePublicCloud/" manifest_staging/deploy/azure-wi-webhook.yaml
-          sed -i "s|image: .*$|image: ${WEBHOOK_IMAGE}|g" manifest_staging/deploy/azure-wi-webhook.yaml
-          KUBECTL=$(pwd)/hack/tools/bin/kubectl
-          ${KUBECTL} apply -f manifest_staging/deploy/azure-wi-webhook.yaml
-          ${KUBECTL} wait --for=condition=Available --timeout=5m -n azure-workload-identity-system deployment/azure-wi-webhook-controller-manager
-          ${KUBECTL} delete -f manifest_staging/deploy/azure-wi-webhook.yaml --wait --timeout=5m
+          # deploy the webhook, wait for it to
+          # be ready, then uninstall it
+          make deploy uninstall-deploy
         displayName: Verify deployment YAML in manifest_staging/
         env:
           AZURE_TENANT_ID: $(AZURE_TENANT_ID)
-          WEBHOOK_IMAGE: $(REGISTRY)/webhook:$(IMAGE_VERSION)
+          DEPLOYMENT_YAML: true
       - script: make kind-delete
         displayName: Cleanup
         condition: always()
   - job:
-    timeoutInMinutes: 20
+    timeoutInMinutes: 60
     dependsOn:
       - scan_images
       - verify_deployment_yaml
@@ -114,7 +105,7 @@ jobs:
         upgrade_arc:
           ARC_CLUSTER: "true"
   - job:
-    timeoutInMinutes: 40
+    timeoutInMinutes: 60
     dependsOn:
       - scan_images
       - verify_deployment_yaml
@@ -141,8 +132,8 @@ jobs:
           KIND_NODE_VERSION: v1.20.7
         kind_v1_21_2:
           KIND_NODE_VERSION: v1.21.2
-        kind_v1_22_0:
-          KIND_NODE_VERSION: v1.22.0
+        kind_v1_22_2:
+          KIND_NODE_VERSION: v1.22.2
     steps:
       - script: make test-e2e
         displayName: Webhook E2E test suite

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -13,7 +13,7 @@ pool: staging-pool
 
 jobs:
   - job: scan_images
-    timeoutInMinutes: 20
+    timeoutInMinutes: 30
     workspace:
       clean: all
     steps:
@@ -27,8 +27,20 @@ jobs:
         displayName: golangci-lint
       - script: make helm-lint
         displayName: helm lint
-      - script: go mod tidy && git diff --exit-code go.mod go.sum
+      - script: |
+          go mod tidy
+          if ! git diff --exit-code go.mod go.sum; then
+            echo "go.mod/go.sum is not up to date. Please run 'go mod tidy'"
+            exit 1
+          fi
         displayName: go mod tidy
+      - script: |
+          make manifests
+          if ! git diff --exit-code manifest_staging/; then
+            echo "manifest_staging/ is not up to date. Please run 'make manifests'"
+            exit 1
+          fi
+        displayName: make manifests
   - job: unit_test
     timeoutInMinutes: 5
     workspace:
@@ -44,7 +56,7 @@ jobs:
       - script: make shellcheck
         displayName: shellcheck
   - job:
-    timeoutInMinutes: 40
+    timeoutInMinutes: 60
     dependsOn:
     - lint
     - scan_images
@@ -91,8 +103,8 @@ jobs:
           KIND_NODE_VERSION: v1.21.2
           LOCAL_ONLY: "true"
           TEST_HELM_CHART: "true"
-        kind_v1_22_0:
-          KIND_NODE_VERSION: v1.22.0
+        kind_v1_22_2:
+          KIND_NODE_VERSION: v1.22.2
           LOCAL_ONLY: "true"
           TEST_HELM_CHART: "true"
     steps:

--- a/.pipelines/templates/upgrade.yaml
+++ b/.pipelines/templates/upgrade.yaml
@@ -6,7 +6,7 @@ parameters:
 
 jobs:
   - job:
-    timeoutInMinutes: 60
+    timeoutInMinutes: 90
     dependsOn: ${{ parameters.dependsOn }}
     workspace:
       clean: all


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Fixes failure in https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/results?buildId=30560&view=results

- bump v1.22 kind version to v1.22.2 
- increase timeout since we occasionally experience slow connection when pulling images from dockerhub
- add a new linting step to ensure the deployment YAML is up-to-date

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
