### PR TITLE
docs: document tenant conditional access policy

### DIFF
--- a/docs/book/src/known-issues.md
+++ b/docs/book/src/known-issues.md
@@ -24,7 +24,7 @@ spec:
 
 ## User tried to log in to a device from a platform (Unknown) that's currently not supported through Conditional Access policy
 
-When creating a federated identity, your request might be blocked by Azure Active Directory's [Conditional Access: Require compliant devices](https://docs.microsoft.com/en-us/azure/active-directory/conditional-access/howto-conditional-access-policy-compliant-device) policy:
+When creating a federated identity credential, your request might be blocked by Azure Active Directory [Conditional Access: Require compliant devices](https://docs.microsoft.com/en-us/azure/active-directory/conditional-access/howto-conditional-access-policy-compliant-device) policy:
 
 ```bash
 az rest --method POST --uri "https://graph.microsoft.com/beta/applications/${APPLICATION_OBJECT_ID}/federatedIdentityCredentials" --body @body.json
@@ -49,6 +49,7 @@ In the case of service principal, you will have to grant the `Application.ReadWr
 
 ```bash
 # get the app role ID of `Application.ReadWrite.All`
+APPLICATION_OBJECT_ID="$(az ad app show --id ${APPLICATION_CLIENT_ID} --query objectId -otsv)"
 GRAPH_RESOURCE_ID="$(az ad sp list --display-name "Microsoft Graph" --query '[0].objectId' -otsv)"
 APPLICATION_READWRITE_ALL_ID="$(az ad sp list --display-name "Microsoft Graph" --query "[0].appRoles[?value=='Application.ReadWrite.All' && contains(allowedMemberTypes, 'Application')].id" --output tsv)"
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Documenting tenant conditional access policy.

Fixes #246

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
