### PR TITLE
docs: fix issuer url query value for aks

### DIFF
--- a/docs/book/src/installation/managed-clusters.md
+++ b/docs/book/src/installation/managed-clusters.md
@@ -11,7 +11,7 @@ Before deploying Azure AD Workload Identity, you will need to enable any **OIDC-
 ```bash
 az aks [create|update] --resource-group <resource_group> --name <cluster_name> --enable-oidc-issuer
 # Output the OIDC issuer URL
-az aks show --resource-group <resource_group> --name <cluster_name> --query ".oidcIssuerProfile.issuerUrl" -otsv
+az aks show --resource-group <resource_group> --name <cluster_name> --query "oidcIssuerProfile.issuerUrl" -otsv
 ```
 
 ## Amazon Elastic Kubernetes Service (EKS)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
```bash
➜ az aks show -g "${RESOURCE_GROUP}" --name "${CLUSTER_NAME}" --query ".oidcIssuerProfile.issuerUrl" -otsv
argument --query: invalid jmespath_type value: '.oidcIssuerProfile.issuerUrl'
To learn more about --query, please visit: 'https://docs.microsoft.com/cli/azure/query-azure-cli'

➜ az aks show -g "${RESOURCE_GROUP}" --name "${CLUSTER_NAME}" --query "oidcIssuerProfile.issuerUrl" -otsv
The behavior of this command has been altered by the following extension: aks-preview
https://oidc.prod-aks.azure.com/e47faa49-0712-4cf3-8a96-440c67069b88/
```

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
