### PR TITLE
test: enable token exchange and proxy test scenario on soak clusters

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -67,27 +67,40 @@ jobs:
     workspace:
       clean: all
     variables:
-      # we can enable actual tenant id for functional e2e
-      AZURE_TENANT_ID: "fake tenant id"
-      REGISTRY: upstreamk8sci.azurecr.io/azure-workload-identity
-      SOAK_CLUSTER: "true"
-      GINKGO_SKIP: \[KindOnly\]
+      # contains the following environment variables:
+      # - APPLICATION_CLIENT_ID
+      # - AZURE_TENANT_ID
+      # - KEYVAULT_NAME
+      # - KEYVAULT_SECRET_NAME
+      - group: e2e-environment-variables
+      - name: REGISTRY
+        value: upstreamk8sci.azurecr.io/azure-workload-identity
+      - name: SOAK_CLUSTER
+        value: "true"
     strategy:
       matrix:
         soak_aks_windows_dockershim:
           WINDOWS_CLUSTER: "true"
-          CLUSTER_NAME: "pmi-aks-win-dockershim"
+          GINKGO_SKIP: \[LinuxOnly\]
+          CLUSTER_NAME: "azwi-aks-win-dockershim"
         soak_aks_windows_containerd:
           WINDOWS_CLUSTER: "true"
-          CLUSTER_NAME: "pmi-aks-win-containerd"
+          GINKGO_SKIP: \[LinuxOnly\]
+          CLUSTER_NAME: "azwi-aks-win-containerd"
         soak_aks_linux:
-          CLUSTER_NAME: "pmi-aks-linux"
+          CLUSTER_NAME: "azwi-aks-linux"
         soak_arc:
           ARC_CLUSTER: "true"
-          CLUSTER_NAME: "pmi-aks-arc"
+          CLUSTER_NAME: "azwi-aks-arc"
+          GINKGO_SKIP: \[Exclude:Arc\]
     steps:
       - script: make test-e2e
         displayName: Webhook E2E test suite
+        env:
+          APPLICATION_CLIENT_ID: $(APPLICATION_CLIENT_ID)
+          AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+          KEYVAULT_NAME: $(KEYVAULT_NAME)
+          KEYVAULT_SECRET_NAME: $(KEYVAULT_SECRET_NAME)
       - template: templates/publish-logs.yaml
   - template: templates/upgrade.yaml
     parameters:
@@ -97,13 +110,16 @@ jobs:
       matrix:
         upgrade_aks_windows_dockershim:
           WINDOWS_CLUSTER: "true"
+          GINKGO_SKIP: \[AKSSoakOnly\]
         upgrade_aks_windows_containerd:
           WINDOWS_CLUSTER: "true"
           WINDOWS_CONTAINERD: "true"
+          GINKGO_SKIP: \[AKSSoakOnly\]
         upgrade_aks_linux:
-          DUMMY_VAR: ""
+          GINKGO_SKIP: \[AKSSoakOnly\]
         upgrade_arc:
           ARC_CLUSTER: "true"
+          GINKGO_SKIP: \[AKSSoakOnly\]
   - job:
     timeoutInMinutes: 60
     dependsOn:

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -78,19 +78,19 @@ jobs:
         aks_windows_dockershim:
           REGISTRY: upstreamk8sci.azurecr.io/azure-workload-identity
           WINDOWS_CLUSTER: "true"
-          GINKGO_SKIP: \[KindOnly\]
+          GINKGO_SKIP: \[AKSSoakOnly\]
         aks_windows_containerd:
           REGISTRY: upstreamk8sci.azurecr.io/azure-workload-identity
           WINDOWS_CLUSTER: "true"
           WINDOWS_CONTAINERD: "true"
-          GINKGO_SKIP: \[KindOnly\]
+          GINKGO_SKIP: \[AKSSoakOnly\]
         aks_linux:
           REGISTRY: upstreamk8sci.azurecr.io/azure-workload-identity
-          GINKGO_SKIP: \[KindOnly\]
+          GINKGO_SKIP: \[AKSSoakOnly\]
         arc:
           REGISTRY: upstreamk8sci.azurecr.io/azure-workload-identity
           ARC_CLUSTER: "true"
-          GINKGO_SKIP: \[KindOnly\]
+          GINKGO_SKIP: \[AKSSoakOnly\]
         kind_v1_20_7:
           KIND_NODE_VERSION: v1.20.7
           LOCAL_ONLY: "true"
@@ -129,4 +129,4 @@ jobs:
         - unit_test
       matrix:
         upgrade_aks_linux:
-          DUMMY_VAR: ""
+          GINKGO_SKIP: \[AKSSoakOnly\]

--- a/.pipelines/templates/upgrade.yaml
+++ b/.pipelines/templates/upgrade.yaml
@@ -11,10 +11,14 @@ jobs:
     workspace:
       clean: all
     variables:
-      # we can enable actual tenant id for functional e2e
-      AZURE_TENANT_ID: "fake tenant id"
-      REGISTRY: upstreamk8sci.azurecr.io/azure-workload-identity
-      GINKGO_SKIP: \[KindOnly\]
+      # contains the following environment variables:
+      # - APPLICATION_CLIENT_ID
+      # - AZURE_TENANT_ID
+      # - KEYVAULT_NAME
+      # - KEYVAULT_SECRET_NAME
+      - group: e2e-environment-variables
+      - name: REGISTRY
+        value: upstreamk8sci.azurecr.io/azure-workload-identity
     strategy:
       matrix: ${{ parameters.matrix }}
     steps:
@@ -24,6 +28,10 @@ jobs:
         displayName: Webhook E2E test suite
         env:
           SKIP_CLEANUP: "true"
+          APPLICATION_CLIENT_ID: $(APPLICATION_CLIENT_ID)
+          AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+          KEYVAULT_NAME: $(KEYVAULT_NAME)
+          KEYVAULT_SECRET_NAME: $(KEYVAULT_SECRET_NAME)
       - script: |
           # xref: https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/512316adc9daa2216de10a6288f6c1df8a122654/.pipelines/templates/aks-upgrade.yaml#L3-L8
           MINOR_VERSION="$(az aks get-upgrades --resource-group ${CLUSTER_NAME} --name ${CLUSTER_NAME} --query "controlPlaneProfile.kubernetesVersion" | jq -r 'split(".") | .[:2] | join(".")')"
@@ -35,6 +43,11 @@ jobs:
         displayName: Upgrade cluster
       - script: make test-e2e
         displayName: Webhook E2E test suite
+        env:
+          APPLICATION_CLIENT_ID: $(APPLICATION_CLIENT_ID)
+          AZURE_TENANT_ID: $(AZURE_TENANT_ID)
+          KEYVAULT_NAME: $(KEYVAULT_NAME)
+          KEYVAULT_SECRET_NAME: $(KEYVAULT_SECRET_NAME)
       - script: az group delete --name "${CLUSTER_NAME}" --yes --no-wait || true
         displayName: Cleanup
         condition: always()

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -47,9 +47,8 @@ create_cluster() {
       az role assignment create --assignee-object-id "${ASSIGNEE_OBJECT_ID}" --role AcrPull --scope "${REGISTRY_SCOPE}" > /dev/null
     fi
 
-    echo "Building controller and deploying webhook to the cluster"
-    # only build webhook since AKS clusters don't have support for proxy and proxy init
-    ALL_IMAGES=webhook make docker-build docker-push-manifest
+    # build webhook manager and msal-go-e2e images
+    ALL_LINUX_ARCH="amd64" make docker-build docker-push-manifest docker-build-e2e-msal-go
   fi
   ${KUBECTL} get nodes -owide
 }

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -17,9 +17,10 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
-// Only kind cluster supports custom service account issuer for now.
 // The proxy implementation is only for Linux.
-var _ = ginkgo.Describe("Proxy [KindOnly] [LinuxOnly]", func() {
+// Run this test in nightly jobs only because we can't establish federated
+// identity under the Microsoft tenant at runtime at the moment.
+var _ = ginkgo.Describe("Proxy [LinuxOnly] [AKSSoakOnly] [Exclude:Arc]", func() {
 	f := framework.NewDefaultFramework("proxy")
 
 	ginkgo.It("should get a valid AAD token with the proxy sidecar", func() {

--- a/test/e2e/token_exchange.go
+++ b/test/e2e/token_exchange.go
@@ -18,7 +18,11 @@ import (
 )
 
 // Only kind cluster supports custom service account issuer for now.
-var _ = ginkgo.Describe("TokenExchange [KindOnly]", func() {
+// Run this test in nightly jobs only because we can't establish federated
+// identity under the Microsoft tenant at runtime at the moment.
+// This test also can't be run on Arc-enabled clusters because it requires
+// the projected service account token to be stored as a Kubernetes secret.
+var _ = ginkgo.Describe("TokenExchange [AKSSoakOnly] [Exclude:Arc]", func() {
 	f := framework.NewDefaultFramework("token-exchange")
 
 	// E2E scenario from https://github.com/Azure/azure-workload-identity/tree/main/examples/msal-go


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Enabling token exchange and proxy test scenario on soak clusters. We won't be able to enable them in PR gates since we can't establish federated identity credentials under the Microsoft tenant at runtime at the moment.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

ref #9 
fixes https://github.com/Azure/azure-workload-identity/issues/284

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
