### PR TITLE
chore: update debian-iptables to bullseye-v1.1.0

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-iptables:bullseye-v1.0.0
+FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-iptables:bullseye-v1.1.0
 
-# upgrading libssl1.1 due to CVE-2021-3711
+# upgrading libssl1.1 due to CVE-2021-3711 and CVE-2021-3712
 # upgrading libgssapi-krb5-2 and libk5crypto3 due to CVE-2021-37750
 RUN clean-install ca-certificates libssl1.1 libgssapi-krb5-2 libk5crypto3
 COPY ./init/init-iptables.sh /bin/


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Updates proxy-init base image to `debian-iptables:bullseye-v1.1.0`
- Adds new CVE to the dockerfile comment

CVE reference:
```bash
➜ trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL k8s.gcr.io/build-image/debian-iptables:bullseye-v1.1.0
2021-12-02T18:20:55.235Z	INFO	Need to update DB
2021-12-02T18:20:55.235Z	INFO	Downloading DB...
25.06 MiB / 25.06 MiB [-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 12.00 MiB p/s 2s
2021-12-02T18:20:59.515Z	INFO	Detected OS: debian
2021-12-02T18:20:59.515Z	INFO	Detecting Debian vulnerabilities...
2021-12-02T18:20:59.524Z	INFO	Number of language-specific files: 0

k8s.gcr.io/build-image/debian-iptables:bullseye-v1.1.0 (debian 11.0)
====================================================================
Total: 6 (MEDIUM: 4, HIGH: 1, CRITICAL: 1)

+------------------+------------------+----------+-------------------+------------------+---------------------------------------+
|     LIBRARY      | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                 TITLE                 |
+------------------+------------------+----------+-------------------+------------------+---------------------------------------+
| libgssapi-krb5-2 | CVE-2021-37750   | MEDIUM   | 1.18.3-6          | 1.18.3-6+deb11u1 | krb5: NULL pointer dereference        |
|                  |                  |          |                   |                  | in process_tgs_req() in               |
|                  |                  |          |                   |                  | kdc/do_tgs_req.c via a FAST inner...  |
|                  |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-37750 |
+------------------+                  +          +                   +                  +                                       +
| libk5crypto3     |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
+------------------+                  +          +                   +                  +                                       +
| libkrb5-3        |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
+------------------+                  +          +                   +                  +                                       +
| libkrb5support0  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
|                  |                  |          |                   |                  |                                       |
+------------------+------------------+----------+-------------------+------------------+---------------------------------------+
| libssl1.1        | CVE-2021-3711    | CRITICAL | 1.1.1k-1          | 1.1.1k-1+deb11u1 | openssl: SM2 Decryption               |
|                  |                  |          |                   |                  | Buffer Overflow                       |
|                  |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3711  |
+                  +------------------+----------+                   +                  +---------------------------------------+
|                  | CVE-2021-3712    | HIGH     |                   |                  | openssl: Read buffer overruns         |
|                  |                  |          |                   |                  | processing ASN.1 strings              |
|                  |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3712  |
+------------------+------------------+----------+-------------------+------------------+---------------------------------------+
```

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
