### PR TITLE
test: set subscription after login

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -70,6 +70,7 @@ trap cleanup EXIT
 
 main() {
   az login -i > /dev/null && echo "Using machine identity for az commands" || echo "Using pre-existing credential for az commands"
+  az account set --subscription "${AZURE_SUBSCRIPTION_ID}" > /dev/null
 
   create_cluster
   make deploy


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
Fixes nightly run failures: https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/results?buildId=33438&view=results where the wrong sub is being chosen. Setting the subscription after login to make it more deterministic.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
Added `AZURE_SUBSCRIPTION_ID` to the library here: https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=26&path=e2e-environment-variables