### PR TITLE
release: update manifest and helm charts for v0.7.0 (revision)

### DIFF
--- a/.github/workflows/create-tag.yaml
+++ b/.github/workflows/create-tag.yaml
@@ -30,47 +30,49 @@ jobs:
           git tag ${{ steps.get-tag.outputs.tag }}
           go install github.com/git-chglog/git-chglog/cmd/git-chglog@v0.15.0
           git-chglog ${{ steps.get-tag.outputs.tag }} > CHANGELOG.md
-      - name: Build azwi-cli
-        run: |
-          build() {
-            export GOOS="$(echo ${1} | cut -d '-' -f 1)"
-            export GOARCH="$(echo ${1} | cut -d '-' -f 2)"
+      # the following step is taking way too long, so we're skipping it for now
+      # and investigating a way to speed it up with goreleaser
+      # - name: Build azwi-cli
+      #   run: |
+      #     build() {
+      #       export GOOS="$(echo ${1} | cut -d '-' -f 1)"
+      #       export GOARCH="$(echo ${1} | cut -d '-' -f 2)"
 
-            # in case of windows, we need to append .exe to the file name
-            EXTENSION="$(echo ${1} | cut -d '-' -f 3)"
-            EXTENSION=${EXTENSION/exe/.exe}
+      #       # in case of windows, we need to append .exe to the file name
+      #       EXTENSION="$(echo ${1} | cut -d '-' -f 3)"
+      #       EXTENSION=${EXTENSION/exe/.exe}
 
-            # build the binary
-            make bin/azwi-${GOOS}-${GOARCH}${EXTENSION}
+      #       # build the binary
+      #       make bin/azwi-${GOOS}-${GOARCH}${EXTENSION}
 
-            # rename the binary to azwi
-            tmp_dir=$(mktemp -d)
-            cp bin/azwi-${GOOS}-${GOARCH}${EXTENSION} ${tmp_dir}/azwi${EXTENSION}
+      #       # rename the binary to azwi
+      #       tmp_dir=$(mktemp -d)
+      #       cp bin/azwi-${GOOS}-${GOARCH}${EXTENSION} ${tmp_dir}/azwi${EXTENSION}
 
-            pushd ${tmp_dir}
-            if [[ ${EXTENSION} == ".exe" ]]; then
-              zip ${GITHUB_WORKSPACE}/_dist/azwi-$${{ steps.get-tag.outputs.tag }}-${GOOS}-${GOARCH}.zip azwi*.exe
-            else
-              tar -czf ${GITHUB_WORKSPACE}/_dist/azwi-${{ steps.get-tag.outputs.tag }}-${GOOS}-${GOARCH}.tar.gz azwi*
-            fi
-            popd
-            rm -rf ${tmp_dir}
-          }
+      #       pushd ${tmp_dir}
+      #       if [[ ${EXTENSION} == ".exe" ]]; then
+      #         zip ${GITHUB_WORKSPACE}/_dist/azwi-$${{ steps.get-tag.outputs.tag }}-${GOOS}-${GOARCH}.zip azwi*.exe
+      #       else
+      #         tar -czf ${GITHUB_WORKSPACE}/_dist/azwi-${{ steps.get-tag.outputs.tag }}-${GOOS}-${GOARCH}.tar.gz azwi*
+      #       fi
+      #       popd
+      #       rm -rf ${tmp_dir}
+      #     }
 
-          mkdir -p _dist
-          make clean
-          for os_arch_extension in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 windows-amd64-exe; do
-            build ${os_arch_extension} &
-          done
-          wait
+      #     mkdir -p _dist
+      #     make clean
+      #     for os_arch_extension in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 windows-amd64-exe; do
+      #       build ${os_arch_extension} &
+      #     done
+      #     wait
 
-          pushd _dist
-          # consolidate tar and zip's sha256sum into a single file
-          find . -type f -name '*.tar.gz' -o -name '*.zip' | sort | xargs sha256sum >> sha256sums.txt
-          popd
+      #     pushd _dist
+      #     # consolidate tar and zip's sha256sum into a single file
+      #     find . -type f -name '*.tar.gz' -o -name '*.zip' | sort | xargs sha256sum >> sha256sums.txt
+      #     popd
       - uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.get-tag.outputs.tag }}
           bodyFile: CHANGELOG.md
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "deploy/*.yaml,_dist/*"
+          artifacts: "deploy/*.yaml"


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Follow-up PR for #299. Removing azwi build step in create-tag.yaml since it's taking too long. We will be building them locally and upload them after the release.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
