### PR TITLE
test: remove service account token expiration e2e flag

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -103,8 +103,7 @@ test_helm_chart() {
     --create-namespace \
     --wait
   poll_webhook_readiness
-  # TODO(aramase) remove the service account token expiration after v0.7.0 release
-  E2E_EXTRA_ARGS=-e2e.service-account-token-expiration=24h make test-e2e-run
+  make test-e2e-run
 
   ${HELM} upgrade --install workload-identity-webhook "${REPO_ROOT}/manifest_staging/charts/workload-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/workload-identity/webhook}" \

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -25,11 +25,10 @@ import (
 )
 
 var (
-	arcCluster                    bool
-	tokenExchangeE2EImage         string
-	proxyInitImage                string
-	proxyImage                    string
-	serviceAccountTokenExpiration time.Duration
+	arcCluster            bool
+	tokenExchangeE2EImage string
+	proxyInitImage        string
+	proxyImage            string
 
 	c              *kubernetes.Clientset
 	coreNamespaces = []string{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -6,9 +6,6 @@ import (
 	"flag"
 	"os"
 	"testing"
-	"time"
-
-	"github.com/Azure/azure-workload-identity/pkg/webhook"
 
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
@@ -19,9 +16,6 @@ func init() {
 	flag.StringVar(&tokenExchangeE2EImage, "e2e.token-exchange-image", "aramase/msal-go:v0.6.0", "The image to use for token exchange tests")
 	flag.StringVar(&proxyInitImage, "e2e.proxy-init-image", "mcr.microsoft.com/oss/azure/workload-identity/proxy-init:v0.7.0", "The proxy-init image")
 	flag.StringVar(&proxyImage, "e2e.proxy-image", "mcr.microsoft.com/oss/azure/workload-identity/proxy:v0.7.0", "The proxy image")
-	// This is only required because webhook v0.6.0 uses 86400 for default token expiration and we are running upgrade tests.
-	// TODO(aramase): remove this flag after v0.7.0 release
-	flag.DurationVar(&serviceAccountTokenExpiration, "e2e.service-account-token-expiration", time.Duration(webhook.DefaultServiceAccountTokenExpiration)*time.Second, "The service account token expiration")
 }
 
 // handleFlags sets up all flags and parses the command line.

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -312,10 +312,7 @@ func validateUnmutatedContainers(f *framework.Framework, pod *corev1.Pod, skipCo
 }
 
 func getVolumeProjectionSources(serviceAccountName string) []corev1.VolumeProjection {
-	// This is only required because webhook v0.6.0 uses 86400 for default token expiration
-	// and we are running upgrade tests.
-	// TODO(aramase): remove this after next release
-	expirationSeconds := int64(serviceAccountTokenExpiration.Seconds())
+	expirationSeconds := webhook.DefaultServiceAccountTokenExpiration
 
 	if arcCluster {
 		return []corev1.VolumeProjection{{


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
`e2e.service-account-token-expiration` was added to support upgrade testing from `v0.6.0` to latest. `v0.7.0` is now released and we no longer need this flag. This will also fix the helm upgrade failures in the nightly runs: https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/results?buildId=33621&view=results

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
