### PR TITLE
test: bump kubernetes version to v1.23.1

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -148,8 +148,8 @@ jobs:
           KIND_NODE_VERSION: v1.21.2
         kind_v1_22_4:
           KIND_NODE_VERSION: v1.22.4
-        kind_v1_23_0:
-          KIND_NODE_VERSION: v1.23.0
+        kind_v1_23_1:
+          KIND_NODE_VERSION: v1.23.1
     steps:
       - script: make test-e2e
         displayName: Webhook E2E test suite

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -102,8 +102,8 @@ jobs:
           KIND_NODE_VERSION: v1.22.4
           LOCAL_ONLY: "true"
           TEST_HELM_CHART: "true"
-        kind_v1_23_0:
-          KIND_NODE_VERSION: v1.23.0
+        kind_v1_23_1:
+          KIND_NODE_VERSION: v1.23.1
           LOCAL_ONLY: "true"
           TEST_HELM_CHART: "true"
     steps:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
