### PR TITLE
fix: generate federated identity credential name based on service account

### DIFF
--- a/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential.go
+++ b/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential.go
@@ -3,6 +3,7 @@ package phases
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/options"
@@ -66,6 +67,7 @@ func (p *federatedIdentityPhase) run(ctx context.Context, data workflow.RunData)
 
 	serviceAccountNamespace, serviceAccountName := createData.ServiceAccountNamespace(), createData.ServiceAccountName()
 	subject := util.GetFederatedCredentialSubject(serviceAccountNamespace, serviceAccountName)
+	name := strings.Join([]string{createData.ServiceAccountNamespace(), createData.ServiceAccountName(), util.GetIssuerHash(createData.ServiceAccountIssuerURL())}, "-")
 	description := fmt.Sprintf("Federated Service Account for %s/%s", serviceAccountNamespace, serviceAccountName)
 	audiences := []string{webhook.DefaultAudience}
 
@@ -75,7 +77,7 @@ func (p *federatedIdentityPhase) run(ctx context.Context, data workflow.RunData)
 	fic.SetDescription(to.StringPtr(description))
 	fic.SetIssuer(to.StringPtr(createData.ServiceAccountIssuerURL()))
 	fic.SetSubject(to.StringPtr(subject))
-	fic.SetName(to.StringPtr("federatedcredential-from-azwi-cli"))
+	fic.SetName(to.StringPtr(name))
 
 	err := createData.AzureClient().AddFederatedCredential(ctx, objectID, fic)
 	if err != nil {

--- a/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential_test.go
@@ -3,6 +3,7 @@ package phases
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
@@ -81,7 +82,7 @@ func TestFederatedIdentityRun(t *testing.T) {
 	fic.SetDescription(to.StringPtr(fmt.Sprintf("Federated Service Account for %s/%s", data.serviceAccountNamespace, data.serviceAccountName)))
 	fic.SetIssuer(to.StringPtr(data.serviceAccountIssuerURL))
 	fic.SetSubject(to.StringPtr(util.GetFederatedCredentialSubject(data.serviceAccountNamespace, data.serviceAccountName)))
-	fic.SetName(to.StringPtr("federatedcredential-from-azwi-cli"))
+	fic.SetName(to.StringPtr(strings.Join([]string{data.ServiceAccountNamespace(), data.ServiceAccountName(), util.GetIssuerHash(data.ServiceAccountIssuerURL())}, "-")))
 
 	mockAzureClient := mock_cloud.NewMockInterface(ctrl)
 	mockAzureClient.EXPECT().AddFederatedCredential(gomock.Any(), "aad-application-object-id", fic).Return(nil)


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Fixes #290. This PR will allow `azwi` to append new federated identity credential to a list of existing one.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
