### PR TITLE
chore: use `pull_request_target` and fix broken doc links

### DIFF
--- a/.github/workflows/azwi-e2e.yaml
+++ b/.github/workflows/azwi-e2e.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # nightly
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - release-**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Azure AD Workload Identity is the next iteration of [Azure AD Pod Identity][1] t
 
 ## Installation
 
-Check out the [installation guide][16] on how to deploy the Azure AD Workload Identity webhook.
+Check out the [installation guide][12] on how to deploy the Azure AD Workload Identity webhook.
 
 ## Quick Start
 
@@ -35,13 +35,9 @@ Azure AD Workload Identity is an open source project that is [**not** covered by
 
 [3]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 
-[4]: https://azure.github.io/azure-workload-identity/quick-start.html
+[4]: https://azure.github.io/azure-workload-identity/docs/quick-start.html
 
-[5]: https://azure.github.io/azure-workload-identity/topics/mutating-admission-webhook.html
-
-[6]: https://azure.github.io/azure-workload-identity/concepts.html#proxy-init
-
-[7]: https://azure.github.io/azure-workload-identity/concepts.html#proxy
+[5]: https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html
 
 [8]: https://azure.github.io/aad-pod-identity/docs/getting-started/role-assignment/
 
@@ -51,15 +47,13 @@ Azure AD Workload Identity is an open source project that is [**not** covered by
 
 [11]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
 
-[12]: https://azure.github.io/azure-workload-identity/installation.html
+[12]: https://azure.github.io/azure-workload-identity/docs/installation.html
 
 [13]: https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/latest?definitionId=365&branchName=main
 
 [14]: https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_apis/build/status/Azure%20Workload%20Identity%20Nightly?branchName=main
 
-[15]: https://azure.github.io/azure-workload-identity/known-issues.html#permission-denied-when-reading-the-projected-service-account-token-file
-
-[16]: https://azure.github.io/azure-workload-identity/installation
+[15]: https://azure.github.io/azure-workload-identity/docs/known-issues.html#permission-denied-when-reading-the-projected-service-account-token-file
 
 [17]: https://opensource.microsoft.com/codeofconduct/
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- `pull_request_target` is required for access to secrets from fork: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target
- fix broken links in docs with change to `/docs` in the url

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
