### PR TITLE
test: use official charts repo for helm upgrade tests

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -92,12 +92,9 @@ main() {
 test_helm_chart() {
   readonly HELM="${REPO_ROOT}/hack/tools/bin/helm"
 
-  # test helm upgrade from the latest released chart to manifest_staging/chart
-  # TODO(chewong) switch to https://azure.github.io/azure-workload-identity/charts once it is available
-  git checkout origin/gh-pages -- "${REPO_ROOT}/charts/"
-  # shellcheck disable=SC2086
-  LATEST_CHART_TARBALL="$(find ${REPO_ROOT}/charts/workload-identity-webhook-*.tgz | sort | tail -n 1)"
-  ${HELM} install workload-identity-webhook "${LATEST_CHART_TARBALL}" \
+  ${HELM} repo add azure-workload-identity https://azure.github.io/azure-workload-identity/charts
+  ${HELM} repo update
+  ${HELM} install workload-identity-webhook azure-workload-identity/workload-identity-webhook \
     --set azureTenantID="${AZURE_TENANT_ID}" \
     --namespace azure-workload-identity-system \
     --create-namespace \


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #185 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
