### PR TITLE
ci: fix dependabot update-types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types:
-        - "version-update: semver-major"
-        - "version-update: semver-minor"
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
   - package-ecosystem: "npm"
     directory: "/example/msal-node"
     schedule:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
```bash
The property '#/updates/0/ignore/0/update-types/0' value "version-update: semver-major" did not match one of the following values: version-update:semver-major, version-update:semver-minor, version-update:semver-patch
The property '#/updates/0/ignore/0/update-types/1' value "version-update: semver-minor" did not match one of the following values: version-update:semver-major, version-update:semver-minor, version-update:semver-patch
```

It doesn't like the extra space in the config. Validated this on my fork: https://github.com/aramase/azure-workload-identity/runs/4900589418

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
