### PR TITLE
security: fix CVE-2021-3995, CVE-2021-3996

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -3,7 +3,8 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-ipt
 # upgrading libssl1.1 due to CVE-2021-3711 and CVE-2021-3712
 # upgrading libgssapi-krb5-2 and libk5crypto3 due to CVE-2021-37750
 # upgrading libgmp10 due to CVE-2021-43618
-RUN clean-install ca-certificates libssl1.1 libgssapi-krb5-2 libk5crypto3 libgmp10
+# upgrading bsdutils due to CVE-2021-3995 and CVE-2021-3996
+RUN clean-install ca-certificates libssl1.1 libgssapi-krb5-2 libk5crypto3 libgmp10 bsdutils
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh
 # Kubernetes runAsNonRoot requires USER to be numeric


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
```bash
e2e/proxy-init:test-linux-amd64 (debian 11.0)
=============================================
Total: 2 (MEDIUM: 2, HIGH: 0, CRITICAL: 0)

+----------+------------------+----------+-------------------+------------------+--------------------------------------+
| LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                TITLE                 |
+----------+------------------+----------+-------------------+------------------+--------------------------------------+
| bsdutils | CVE-2021-3995    | MEDIUM   | 2.36.1-8          | 2.36.1-8+deb11u1 | util-linux: Unauthorized unmount     |
|          |                  |          |                   |                  | of FUSE filesystems belonging        |
|          |                  |          |                   |                  | to users with similar uid...         |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3995 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2021-3996    |          |                   |                  | util-linux: Unauthorized unmount     |
|          |                  |          |                   |                  | of filesystems in libmount           |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3996 |
+----------+------------------+----------+-------------------+------------------+--------------------------------------+

```

Failure: https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/results?buildId=35757&view=logs&jobId=50e5c204-a982-5a63-4824-cf22f1b24a4e

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**: