### PR TITLE
docs: remove `go install` step for azwi

### DIFF
--- a/docs/book/src/development.md
+++ b/docs/book/src/development.md
@@ -82,13 +82,7 @@ az storage blob upload \
   --name .well-known/openid-configuration
 ```
 
-Install `azwi`:
-
-`azwi` is a CLI tool that helps generate the JWKS document in JSON.
-
-```bash
-go install github.com/Azure/azure-workload-identity/cmd/azwi
-```
+Download `azwi` from our [latest GitHub releases][4], which is a CLI tool that helps generate the JWKS document in JSON.
 
 Generate and upload the JWKS:
 
@@ -244,3 +238,5 @@ Optional settings are:
 [2]: https://golang.org/dl/
 
 [3]: https://stedolan.github.io/jq/
+
+[4]: https://github.com/Azure/azure-workload-identity/releases

--- a/docs/book/src/installation/azwi.md
+++ b/docs/book/src/installation/azwi.md
@@ -9,14 +9,14 @@
     *   Federated identities
     *   Azure role assignments
 
-### `go install`
+### GitHub Releases
 
-```bash
-go install github.com/Azure/azure-workload-identity/cmd/azwi@v0.7.0
-```
+You can download `azwi` from our [latest GitHub releases][1].
 
 ### Homebrew (MacOS only)
 
 ```bash
 brew install Azure/azure-workload-identity/azwi
 ```
+
+[1]: https://github.com/Azure/azure-workload-identity/releases

--- a/docs/book/src/topics/self-managed-clusters/service-account-key-rotation.md
+++ b/docs/book/src/topics/self-managed-clusters/service-account-key-rotation.md
@@ -91,13 +91,7 @@ done
 
 In the case of service account tokens generated before you initiated the key rotation, you would need a time period where the old and new public keys exist in the JWKS. The relying party can then validate service account tokens signed by both the old and new private key.
 
-Install `azwi`:
-
-`azwi` is a CLI tool that helps generate the JWKS document in JSON.
-
-```bash
-go install github.com/Azure/azure-workload-identity/cmd/azwi
-```
+Download `azwi` from our [latest GitHub releases][4], which is a CLI tool that helps generate the JWKS document in JSON.
 
 Generate and upload the JWKS:
 
@@ -215,3 +209,5 @@ rm sa.*
 [2]: ../../quick-start.md
 
 [3]: https://jwt.io/
+
+[4]: https://github.com/Azure/azure-workload-identity/releases


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Fixes #320. Removing `go install` step for azwi and advising users to download the tarball from our latest GitHub releases.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
