### PR TITLE
chore: migrate from `trivy` to `trivy image`

### DIFF
--- a/.pipelines/templates/scan-images.yaml
+++ b/.pipelines/templates/scan-images.yaml
@@ -7,13 +7,13 @@ steps:
       ALL_LINUX_ARCH: amd64 # build amd64 only to speed up PR gate
       OUTPUT_TYPE: type=docker
   - script: |
-      wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION:-0.20.0}/trivy_${TRIVY_VERSION:-0.20.0}_Linux-64bit.tar.gz
-      tar zxvf trivy_${TRIVY_VERSION:-0.20.0}_Linux-64bit.tar.gz
+      wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION:-0.23.0}/trivy_${TRIVY_VERSION:-0.23.0}_Linux-64bit.tar.gz
+      tar zxvf trivy_${TRIVY_VERSION:-0.23.0}_Linux-64bit.tar.gz
       # show all vulnerabilities in the logs
       ./trivy image --reset
       for IMAGE_NAME in "proxy" "proxy-init" "webhook"; do
-        ./trivy "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-linux-amd64"
-        ./trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-linux-amd64" || exit 1
+        ./trivy image "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-linux-amd64"
+        ./trivy image --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-linux-amd64" || exit 1
       done
     displayName: Scan images
     env:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
ref: https://github.com/aquasecurity/trivy/discussions/1515

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
