### PR TITLE
fix: check for graph error from graph library response

### DIFF
--- a/pkg/cloud/graph.go
+++ b/pkg/cloud/graph.go
@@ -28,7 +28,18 @@ func (c *AzureClient) CreateServicePrincipal(ctx context.Context, appID string, 
 	spPostOptions.Body.SetTags(tags)
 
 	log.Debugf("Creating service principal for application with id=%s", appID)
-	return c.graphServiceClient.ServicePrincipals().Post(spPostOptions)
+	sp, err := c.graphServiceClient.ServicePrincipals().Post(spPostOptions)
+	if err != nil {
+		return nil, err
+	}
+	graphErr, err := GetGraphError(sp.GetAdditionalData())
+	if err != nil {
+		return nil, err
+	}
+	if graphErr != nil {
+		return nil, *graphErr
+	}
+	return sp, nil
 }
 
 // CreateApplication creates an application.
@@ -39,7 +50,18 @@ func (c *AzureClient) CreateApplication(ctx context.Context, displayName string)
 	appPostOptions.Body.SetDisplayName(to.StringPtr(displayName))
 
 	log.Debugf("Creating application with display name=%s", displayName)
-	return c.graphServiceClient.Applications().Post(appPostOptions)
+	app, err := c.graphServiceClient.Applications().Post(appPostOptions)
+	if err != nil {
+		return nil, err
+	}
+	graphErr, err := GetGraphError(app.GetAdditionalData())
+	if err != nil {
+		return nil, err
+	}
+	if graphErr != nil {
+		return nil, *graphErr
+	}
+	return app, nil
 }
 
 // GetServicePrincipal gets a service principal by its display name.
@@ -55,6 +77,13 @@ func (c *AzureClient) GetServicePrincipal(ctx context.Context, displayName strin
 	resp, err := c.graphServiceClient.ServicePrincipals().Get(spGetOptions)
 	if err != nil {
 		return nil, err
+	}
+	graphErr, err := GetGraphError(resp.GetAdditionalData())
+	if err != nil {
+		return nil, err
+	}
+	if graphErr != nil {
+		return nil, *graphErr
 	}
 	if len(resp.GetValue()) == 0 {
 		return nil, errors.Errorf("service principal %s not found", displayName)
@@ -75,6 +104,13 @@ func (c *AzureClient) GetApplication(ctx context.Context, displayName string) (*
 	resp, err := c.graphServiceClient.Applications().Get(appGetOptions)
 	if err != nil {
 		return nil, err
+	}
+	graphErr, err := GetGraphError(resp.GetAdditionalData())
+	if err != nil {
+		return nil, err
+	}
+	if graphErr != nil {
+		return nil, *graphErr
 	}
 	if len(resp.GetValue()) == 0 {
 		return nil, errors.Errorf("application with display name '%s' not found", displayName)

--- a/pkg/cmd/serviceaccount/root.go
+++ b/pkg/cmd/serviceaccount/root.go
@@ -15,6 +15,10 @@ func NewServiceAccountCmd() *cobra.Command {
 		Long:    "Manage the workload identity",
 		Aliases: []string{"sa"},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// run root command pre-run to registry the debug flag
+			if cmd.Root() != nil && cmd.Root().PersistentPreRun != nil {
+				cmd.Root().PersistentPreRun(cmd.Root(), args)
+			}
 			return authProvider.Validate()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/serviceaccount/root.go
+++ b/pkg/cmd/serviceaccount/root.go
@@ -15,7 +15,7 @@ func NewServiceAccountCmd() *cobra.Command {
 		Long:    "Manage the workload identity",
 		Aliases: []string{"sa"},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// run root command pre-run to registry the debug flag
+			// run root command pre-run to register the debug flag
 			if cmd.Root() != nil && cmd.Root().PersistentPreRun != nil {
 				cmd.Root().PersistentPreRun(cmd.Root(), args)
 			}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Fixes #352.

We should always check for graph errors from graph library responses before returning the graph objects. This PR also fixes `--debug` flag where it wasn't working when specificed.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
