### PR TITLE
fix: change mount path to `/var/run/secrets/azure/tokens`

### DIFF
--- a/docs/book/src/installation.md
+++ b/docs/book/src/installation.md
@@ -17,7 +17,7 @@
 
 | Component                               | Description                                                                                                                                                                                                            | Guide     |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| Mutating Admission Webhook              | Projects a signed service account token to a well-known path (`/var/run/secrets/tokens/azure-identity-token`) and inject authentication-related environment variables to your pods based on annotated service account. | [Link][5] |
+| Mutating Admission Webhook              | Projects a signed service account token to a well-known path (`/var/run/secrets/azure/tokens/azure-identity-token`) and inject authentication-related environment variables to your pods based on annotated service account. | [Link][5] |
 | Azure AD Workload Identity CLI (`azwi`) | A utility CLI that helps manage Azure AD Workload Identity and automate error-prone operations.                                                                                                                        | [Link][6] |
 
 [1]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli

--- a/docs/book/src/installation/mutating-admission-webhook.md
+++ b/docs/book/src/installation/mutating-admission-webhook.md
@@ -16,9 +16,9 @@ Azure AD Workload Identity uses a [mutating admission webhook][1] to project a s
 | ---------------------- | ------------------------------------- |
 | `azure-identity-token` | The projected service account volume. |
 
-| Volume mount                                   | Description                                           |
-| ---------------------------------------------- | ----------------------------------------------------- |
-| `/var/run/secrets/tokens/azure-identity-token` | The path of the projected service account token file. |
+| Volume mount                                         | Description                                           |
+| ---------------------------------------------------- | ----------------------------------------------------- |
+| `/var/run/secrets/azure/tokens/azure-identity-token` | The path of the projected service account token file. |
 
 </details>
 

--- a/docs/book/src/known-issues.md
+++ b/docs/book/src/known-issues.md
@@ -5,7 +5,7 @@
 In Kubernetes 1.18, the default mode for the projected service account token file is `0600`. This causes containers running as non-root to fail while trying to read the token file:
 
 ```bash
-F0826 20:03:20.113998 1 main.go:27] failed to get secret from keyvault, err: autorest/Client#Do: Preparing request failed: StatusCode=0 -- Original Error: failed to read service account token: open /var/run/secrets/tokens/azure-identity-token: permission denied
+F0826 20:03:20.113998 1 main.go:27] failed to get secret from keyvault, err: autorest/Client#Do: Preparing request failed: StatusCode=0 -- Original Error: failed to read service account token: open /var/run/secrets/azure/tokens/azure-identity-token: permission denied
 ```
 
 The default mode was changed to `0644` in Kubernetes v1.19, which allows containers running as non-root to read the projected service account token.

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -267,9 +267,9 @@ You can verify the following injected properties in the output:
 
 <br/>
 
-| Volume mount                                   | Description                                           |
-| ---------------------------------------------- | ----------------------------------------------------- |
-| `/var/run/secrets/tokens/azure-identity-token` | The path of the projected service account token file. |
+| Volume mount                                         | Description                                           |
+| ---------------------------------------------------- | ----------------------------------------------------- |
+| `/var/run/secrets/azure/tokens/azure-identity-token` | The path of the projected service account token file. |
 
 <br/>
 
@@ -309,7 +309,7 @@ Containers:
       AZURE_FEDERATED_TOKEN_FILE: (Injected by the webhook)
     Mounts:
       /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-844ns (ro)
-      /var/run/secrets/tokens from azure-identity-token (ro) (Injected by the webhook)
+      /var/run/secrets/azure/tokens from azure-identity-token (ro) (Injected by the webhook)
 Conditions:
   Type              Status
   Initialized       True

--- a/docs/book/src/topics/self-managed-clusters/service-account-key-rotation.md
+++ b/docs/book/src/topics/self-managed-clusters/service-account-key-rotation.md
@@ -161,7 +161,7 @@ EOF
 Output the projected service account token:
 
 ```bash
-kubectl exec dummy-pod -- cat /var/run/secrets/tokens/azure-identity-token
+kubectl exec dummy-pod -- cat /var/run/secrets/azure/tokens/azure-identity-token
 ```
 
 Decode your token using [jwt.io][3]. The `kid` field in the token header should be the same as the `kid` of `azwi jwks --public-keys sa-new.pub | jq -r '.keys[0].kid'`. This means that the service account token is signed by the new private key.

--- a/pkg/webhook/consts.go
+++ b/pkg/webhook/consts.go
@@ -32,7 +32,7 @@ const (
 	AzureFederatedTokenFileEnvVar = "AZURE_FEDERATED_TOKEN_FILE" // #nosec
 	AzureAuthorityHostEnvVar      = "AZURE_AUTHORITY_HOST"
 	TokenFilePathName             = "azure-identity-token"
-	TokenFileMountPath            = "/var/run/secrets/tokens" // #nosec
+	TokenFileMountPath            = "/var/run/secrets/azure/tokens" // #nosec
 	// DefaultAudience is the audience added to the service account token audience
 	// This value is to be consistent with other token exchange flows in AAD and has
 	// no impact on the actual token exchange flow.

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -640,7 +640,7 @@ func TestAddProjectServiceAccountTokenVolumeMount(t *testing.T) {
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      TokenFilePathName,
-						MountPath: "/var/run/secrets/tokens",
+						MountPath: TokenFileMountPath,
 						ReadOnly:  true,
 					},
 				},
@@ -691,7 +691,7 @@ func TestAddProjectServiceAccountTokenVolumeMount(t *testing.T) {
 					},
 					{
 						Name:      TokenFilePathName,
-						MountPath: "/var/run/secrets/tokens",
+						MountPath: TokenFileMountPath,
 						ReadOnly:  true,
 					},
 				},
@@ -1074,7 +1074,7 @@ func TestMutateContainers(t *testing.T) {
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      TokenFilePathName,
-					MountPath: "/var/run/secrets/tokens",
+					MountPath: TokenFileMountPath,
 					ReadOnly:  true,
 				},
 			},
@@ -1115,7 +1115,7 @@ func TestMutateContainers(t *testing.T) {
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      TokenFilePathName,
-					MountPath: "/var/run/secrets/tokens",
+					MountPath: TokenFileMountPath,
 					ReadOnly:  true,
 				},
 			},

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -100,7 +100,8 @@ test_helm_chart() {
     --create-namespace \
     --wait
   poll_webhook_readiness
-  make test-e2e-run
+  # TODO(aramase) remove the volume mount path check after v0.8.0 is released
+  E2E_EXTRA_ARGS=-e2e.volume-mount-path-to-check=/var/run/secrets/tokens make test-e2e-run
 
   ${HELM} upgrade --install workload-identity-webhook "${REPO_ROOT}/manifest_staging/charts/workload-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/workload-identity/webhook}" \

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -25,10 +25,11 @@ import (
 )
 
 var (
-	arcCluster            bool
-	tokenExchangeE2EImage string
-	proxyInitImage        string
-	proxyImage            string
+	arcCluster             bool
+	tokenExchangeE2EImage  string
+	proxyInitImage         string
+	proxyImage             string
+	volumeMountPathToCheck string
 
 	c              *kubernetes.Clientset
 	coreNamespaces = []string{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/Azure/azure-workload-identity/pkg/webhook"
+
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
 )
@@ -16,6 +18,7 @@ func init() {
 	flag.StringVar(&tokenExchangeE2EImage, "e2e.token-exchange-image", "aramase/msal-go:v0.6.0", "The image to use for token exchange tests")
 	flag.StringVar(&proxyInitImage, "e2e.proxy-init-image", "mcr.microsoft.com/oss/azure/workload-identity/proxy-init:v0.7.0", "The proxy-init image")
 	flag.StringVar(&proxyImage, "e2e.proxy-image", "mcr.microsoft.com/oss/azure/workload-identity/proxy:v0.7.0", "The proxy image")
+	flag.StringVar(&volumeMountPathToCheck, "e2e.volume-mount-path-to-check", webhook.TokenFileMountPath, "The volume mount path to check")
 }
 
 // handleFlags sets up all flags and parses the command line.

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -206,7 +206,7 @@ func createSecretForArcCluster(c kubernetes.Interface, namespace, serviceAccount
 // 1. verify that all containers except the one in skipContainers have expected environment variables injected;
 // 2. verify that all containers except the one in skipContainers have azure-identity-token mounted;
 // 3. verify that the pod has a service account token volume projected;
-// 4. verify that the pod has access to token file via `cat /var/run/secrets/tokens/azure-identity-token`.
+// 4. verify that the pod has access to token file via `cat /var/run/secrets/azure/tokens/azure-identity-token`.
 func validateMutatedPod(f *framework.Framework, pod *corev1.Pod, skipContainers []string) {
 	withoutSkipContainers := []corev1.Container{}
 	// consider init containers as well
@@ -249,7 +249,7 @@ func validateMutatedPod(f *framework.Framework, pod *corev1.Pod, skipContainers 
 				found = true
 				gomega.Expect(volumeMount).To(gomega.Equal(corev1.VolumeMount{
 					Name:      webhook.TokenFilePathName,
-					MountPath: webhook.TokenFileMountPath,
+					MountPath: volumeMountPathToCheck,
 					ReadOnly:  true,
 				}))
 				break
@@ -285,7 +285,7 @@ func validateMutatedPod(f *framework.Framework, pod *corev1.Pod, skipContainers 
 	if len(withoutSkipContainers) > 0 {
 		err := e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace)
 		framework.ExpectNoError(err, "failed to start pod %s", pod.Name)
-		_ = f.ExecCommandInContainer(pod.Name, withoutSkipContainers[0].Name, "cat", filepath.Join(webhook.TokenFileMountPath, webhook.TokenFilePathName))
+		_ = f.ExecCommandInContainer(pod.Name, withoutSkipContainers[0].Name, "cat", filepath.Join(volumeMountPathToCheck, webhook.TokenFilePathName))
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Changes the mount path configured by webhook to `/var/run/secrets/azure/tokens` as `/var/run/secrets/tokens` could be used for other volume mounts. This change should be backward compatible as the users should rely on `AZURE_FEDERATED_TOKEN_FILE` environment variable which will have the correct value. 

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #357 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
