### PR TITLE
test: remove volume-mount-path-to-check e2e flag

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -100,8 +100,7 @@ test_helm_chart() {
     --create-namespace \
     --wait
   poll_webhook_readiness
-  # TODO(aramase) remove the volume mount path check after v0.8.0 is released
-  E2E_EXTRA_ARGS=-e2e.volume-mount-path-to-check=/var/run/secrets/tokens make test-e2e-run
+  make test-e2e-run
 
   ${HELM} upgrade --install workload-identity-webhook "${REPO_ROOT}/manifest_staging/charts/workload-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/workload-identity/webhook}" \

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -25,11 +25,10 @@ import (
 )
 
 var (
-	arcCluster             bool
-	tokenExchangeE2EImage  string
-	proxyInitImage         string
-	proxyImage             string
-	volumeMountPathToCheck string
+	arcCluster            bool
+	tokenExchangeE2EImage string
+	proxyInitImage        string
+	proxyImage            string
 
 	c              *kubernetes.Clientset
 	coreNamespaces = []string{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
 )
@@ -18,7 +16,6 @@ func init() {
 	flag.StringVar(&tokenExchangeE2EImage, "e2e.token-exchange-image", "aramase/msal-go:v0.6.0", "The image to use for token exchange tests")
 	flag.StringVar(&proxyInitImage, "e2e.proxy-init-image", "mcr.microsoft.com/oss/azure/workload-identity/proxy-init:v0.8.0", "The proxy-init image")
 	flag.StringVar(&proxyImage, "e2e.proxy-image", "mcr.microsoft.com/oss/azure/workload-identity/proxy:v0.8.0", "The proxy image")
-	flag.StringVar(&volumeMountPathToCheck, "e2e.volume-mount-path-to-check", webhook.TokenFileMountPath, "The volume mount path to check")
 }
 
 // handleFlags sets up all flags and parses the command line.

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -249,7 +249,7 @@ func validateMutatedPod(f *framework.Framework, pod *corev1.Pod, skipContainers 
 				found = true
 				gomega.Expect(volumeMount).To(gomega.Equal(corev1.VolumeMount{
 					Name:      webhook.TokenFilePathName,
-					MountPath: volumeMountPathToCheck,
+					MountPath: webhook.TokenFileMountPath,
 					ReadOnly:  true,
 				}))
 				break
@@ -285,7 +285,7 @@ func validateMutatedPod(f *framework.Framework, pod *corev1.Pod, skipContainers 
 	if len(withoutSkipContainers) > 0 {
 		err := e2epod.WaitForPodNameRunningInNamespace(f.ClientSet, pod.Name, pod.Namespace)
 		framework.ExpectNoError(err, "failed to start pod %s", pod.Name)
-		_ = f.ExecCommandInContainer(pod.Name, withoutSkipContainers[0].Name, "cat", filepath.Join(volumeMountPathToCheck, webhook.TokenFilePathName))
+		_ = f.ExecCommandInContainer(pod.Name, withoutSkipContainers[0].Name, "cat", filepath.Join(webhook.TokenFileMountPath, webhook.TokenFilePathName))
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
`e2e.volume-mount-path-to-check` was added to support upgrade testing from `v0.7.0` to latest. `v0.8.0` is now released and we no longer need this flag. This will also fix the helm upgrade failures in the nightly runs: https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/results?buildId=37028&view=results

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
