### PR TITLE
ci: use pull_request instead of pull_request_target for Actions

### DIFF
--- a/.github/workflows/azwi-e2e.yaml
+++ b/.github/workflows/azwi-e2e.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # nightly
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - release-**
@@ -18,9 +18,10 @@ permissions:
 
 jobs:
   azwi_e2e:
-    environment: azwi-e2e
     env:
-      SERVICE_ACCOUNT_ISSUER: ${{ secrets.SERVICE_ACCOUNT_ISSUER }}
+      AZURE_CLIENT_ID: 0dcfc182-7b36-4e23-b53f-a27c929a9e4e
+      AZURE_TENANT_ID: bc2d60ab-9b1d-45bd-8a3b-3a18ae865e3a
+      SERVICE_ACCOUNT_ISSUER: https://chuwon.blob.core.windows.net/oidc-test/"
     strategy:
       fail-fast: false
       matrix:
@@ -29,13 +30,6 @@ jobs:
     runs-on: ${{ matrix.env }}
     steps:
       - name: Checkout
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: Checkout
-        if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -55,16 +49,15 @@ jobs:
           echo "SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAMESPACE}-sa" >> "${GITHUB_ENV}"
       - name: Create kind cluster
         run: |
-          # create a kind cluster with predefined signing keys
-          echo ${{ secrets.SERVICE_ACCOUNT_SIGNING_KEY }} | base64 -d > sa.key
-          echo ${{ secrets.SERVICE_ACCOUNT_KEY }} | base64 -d > sa.pub
+          openssl genrsa -out sa.key 2048
+          openssl rsa -in sa.key -pubout -out sa.pub
           make kind-create
       - name: Build azwi
         run: make bin/azwi
       - uses: azure/login@v1.4.3
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
       - name: E2E test
         run: |
@@ -85,7 +78,7 @@ jobs:
           APPLICATION_CLIENT_ID="$(az ad sp list --display-name "${AAD_APPLICATION_NAME}" --query '[0].appId' -otsv)"
           cat sa.yaml | grep "azure.workload.identity/client-id: ${APPLICATION_CLIENT_ID}"
           cat sa.yaml | grep "azure.workload.identity/service-account-token-expiration: 36000"
-          cat sa.yaml | grep "azure.workload.identity/tenant-id: ${{ secrets.AZURE_TENANT_ID }}"
+          cat sa.yaml | grep "azure.workload.identity/tenant-id: ${AZURE_TENANT_ID}"
 
           # get the federated identity
           APPLICATION_OBJECT_ID="$(az ad app show --id "${APPLICATION_CLIENT_ID}" --query objectId -otsv)"
@@ -111,13 +104,6 @@ jobs:
     runs-on: ${{ matrix.env }}
     steps:
       - name: Checkout
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: Checkout
-        if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/azwi-e2e.yaml
+++ b/.github/workflows/azwi-e2e.yaml
@@ -21,7 +21,7 @@ jobs:
     env:
       AZURE_CLIENT_ID: 0dcfc182-7b36-4e23-b53f-a27c929a9e4e
       AZURE_TENANT_ID: bc2d60ab-9b1d-45bd-8a3b-3a18ae865e3a
-      SERVICE_ACCOUNT_ISSUER: https://chuwon.blob.core.windows.net/oidc-test/"
+      SERVICE_ACCOUNT_ISSUER: "https://chuwon.blob.core.windows.net/oidc-test/"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Uses `pull_request` instead of `pull_request_target` to prevent malicious commits.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
