### PR TITLE
ci: split azwi test workflow for e2e and build

### DIFF
--- a/.github/workflows/azwi-build.yaml
+++ b/.github/workflows/azwi-build.yaml
@@ -1,0 +1,41 @@
+name: Azure Workload Identity CI
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # nightly
+  pull_request:
+    branches:
+      - main
+      - release-**
+    paths-ignore:
+      - docs/**
+      - README.md
+
+jobs:
+  azwi_build:
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO(aramase): add windows test env
+        env: [ubuntu-20.04, macos-11]
+    runs-on: ${{ matrix.env }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.17"
+      - name: Build azwi
+        run: |
+          make bin/azwi
+      - name: Validate azwi commands
+        run: |
+          ./bin/azwi version
+          ./bin/azwi -h
+          ./bin/azwi serviceaccount -h
+          ./bin/azwi serviceaccount create -h
+          ./bin/azwi serviceaccount delete -h
+          ./bin/azwi jwks -h

--- a/.github/workflows/azwi-e2e.yaml
+++ b/.github/workflows/azwi-e2e.yaml
@@ -1,16 +1,13 @@
-name: Azure Workload Identity CI
+name: Azure Workload Identity E2E
 
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # nightly
-  pull_request:
+  push:
     branches:
       - main
       - release-**
-    paths-ignore:
-      - docs/**
-      - README.md
 
 permissions:
   id-token: write


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
`ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variables are not available to forks even with `id-token` permission set to true. As part of this PR, we're splitting the existing azwi CI workflow:
1. Workflow to build azwi that runs periodically and as part of every PR.
2. E2E to create an app, add fic that runs periodically and after merge to main or release branches. 

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
