### PR TITLE
chore: switch to upstream acr

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -74,7 +74,7 @@ jobs:
       # - KEYVAULT_SECRET_NAME
       - group: e2e-environment-variables
       - name: REGISTRY
-        value: upstreamk8sci.azurecr.io/azure-workload-identity
+        value: upstream.azurecr.io/azure-workload-identity
       - name: SOAK_CLUSTER
         value: "true"
     strategy:

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -75,19 +75,19 @@ jobs:
     strategy:
       matrix:
         aks_windows_dockershim:
-          REGISTRY: upstreamk8sci.azurecr.io/azure-workload-identity
+          REGISTRY: upstream.azurecr.io/azure-workload-identity
           WINDOWS_CLUSTER: "true"
           GINKGO_SKIP: \[AKSSoakOnly\]
         aks_windows_containerd:
-          REGISTRY: upstreamk8sci.azurecr.io/azure-workload-identity
+          REGISTRY: upstream.azurecr.io/azure-workload-identity
           WINDOWS_CLUSTER: "true"
           WINDOWS_CONTAINERD: "true"
           GINKGO_SKIP: \[AKSSoakOnly\]
         aks_linux:
-          REGISTRY: upstreamk8sci.azurecr.io/azure-workload-identity
+          REGISTRY: upstream.azurecr.io/azure-workload-identity
           GINKGO_SKIP: \[AKSSoakOnly\]
         arc:
-          REGISTRY: upstreamk8sci.azurecr.io/azure-workload-identity
+          REGISTRY: upstream.azurecr.io/azure-workload-identity
           ARC_CLUSTER: "true"
           GINKGO_SKIP: \[AKSSoakOnly\]
         kind_v1_20_7:

--- a/.pipelines/templates/upgrade.yaml
+++ b/.pipelines/templates/upgrade.yaml
@@ -18,7 +18,7 @@ jobs:
       # - KEYVAULT_SECRET_NAME
       - group: e2e-environment-variables
       - name: REGISTRY
-        value: upstreamk8sci.azurecr.io/azure-workload-identity
+        value: upstream.azurecr.io/azure-workload-identity
     strategy:
       matrix: ${{ parameters.matrix }}
     steps:


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Switching staging registry from using upstreamk8sci to upstream. 

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
