### PR TITLE
fix: update proxy-init iptables rule to prevent forwarding loop

### DIFF
--- a/docker/proxy.Dockerfile
+++ b/docker/proxy.Dockerfile
@@ -24,6 +24,6 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/proxy .
 # Kubernetes runAsNonRoot requires USER to be numeric
-USER 65532:65532
+USER 1501:1501
 
 ENTRYPOINT [ "/proxy" ]

--- a/init/init-iptables.sh
+++ b/init/init-iptables.sh
@@ -3,9 +3,19 @@
 PROXY_PORT=${PROXY_PORT:-8000}
 METADATA_IP=${METADATA_IP:-169.254.169.254}
 METADATA_PORT=${METADATA_PORT:-80}
+PROXY_UID=${PROXY_UID:-1501}
 
-# Forward outbound traffic for metadata endpoint to proxy
-iptables -t nat -A OUTPUT -p tcp -d "${METADATA_IP}" --dport "${METADATA_PORT}" -j REDIRECT --to-port "${PROXY_PORT}"
+iptables -t nat -N AZWI_PROXY_OUTPUT
+iptables -t nat -N AZWI_PROXY_REDIRECT
+
+# Redirect all TCP traffic for metatadata endpoint to the proxy
+iptables -t nat -A AZWI_PROXY_REDIRECT -p tcp -j REDIRECT --to-port "${PROXY_PORT}"
+# For outbound TCP traffic to metadata endpoint on port 80 jump from OUTPUT chain to AZWI_PROXY_OUTPUT chain
+iptables -t nat -A OUTPUT -p tcp -d "${METADATA_IP}" --dport "${METADATA_PORT}" -j AZWI_PROXY_OUTPUT
+# Skip redirection of proxy traffic back to itself, return to next chain for further processing
+iptables -t nat -A AZWI_PROXY_OUTPUT -m owner --uid-owner "${PROXY_UID}" -j ACCEPT
+# For all other traffic to metadata point, jump to AZWI_PROXY_REDIRECT chain
+iptables -t nat -A AZWI_PROXY_OUTPUT -j AZWI_PROXY_REDIRECT
 
 # List all iptables rules
 iptables -t nat --list

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/Azure/azure-workload-identity/pkg/webhook"
 
@@ -150,53 +149,6 @@ func TestRouterPathPrefix(t *testing.T) {
 			rtr.ServeHTTP(recorder, req)
 			if recorder.Body.String() != test.expectedBody {
 				t.Errorf("Expected body %s, got %s", test.expectedBody, recorder.Body.String())
-			}
-		})
-	}
-}
-
-// Vendored from https://github.com/Azure/go-autorest/blob/def88ef859fb980eff240c755a70597bc9b490d0/autorest/adal/token_test.go
-func TestParseExpiresOn(t *testing.T) {
-	// get current time, round to nearest second, and add one hour
-	n := time.Now().UTC().Round(time.Second).Add(time.Hour)
-	amPM := "AM"
-	if n.Hour() >= 12 {
-		amPM = "PM"
-	}
-	testcases := []struct {
-		Name   string
-		String string
-		Value  int64
-	}{
-		{
-			Name:   "integer",
-			String: "3600",
-			Value:  3600,
-		},
-		{
-			Name:   "timestamp with AM/PM",
-			String: fmt.Sprintf("%d/%d/%d %d:%02d:%02d %s +00:00", n.Month(), n.Day(), n.Year(), n.Hour(), n.Minute(), n.Second(), amPM),
-			Value:  3600,
-		},
-		{
-			Name:   "timestamp without AM/PM",
-			String: fmt.Sprintf("%d/%d/%d %d:%02d:%02d +00:00", n.Month(), n.Day(), n.Year(), n.Hour(), n.Minute(), n.Second()),
-			Value:  3600,
-		},
-	}
-	for _, tc := range testcases {
-		t.Run(tc.Name, func(subT *testing.T) {
-			jn, err := parseExpiresOn(tc.String)
-			if err != nil {
-				subT.Error(err)
-			}
-			i, err := jn.Int64()
-			if err != nil {
-				subT.Error(err)
-			}
-			if i != tc.Value {
-				subT.Logf("expected %d, got %d", tc.Value, i)
-				subT.Fail()
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Updates iptables rules to skip redirecting proxy traffic back to itself
- Updates user in `Dockerfile` for proxy 

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
