### PR TITLE
security: fix multiple cves

### DIFF
--- a/.pipelines/templates/scan-images.yaml
+++ b/.pipelines/templates/scan-images.yaml
@@ -7,8 +7,8 @@ steps:
       ALL_LINUX_ARCH: amd64 # build amd64 only to speed up PR gate
       OUTPUT_TYPE: type=docker
   - script: |
-      wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION:-0.23.0}/trivy_${TRIVY_VERSION:-0.23.0}_Linux-64bit.tar.gz
-      tar zxvf trivy_${TRIVY_VERSION:-0.23.0}_Linux-64bit.tar.gz
+      wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION:-0.24.4}/trivy_${TRIVY_VERSION:-0.24.4}_Linux-64bit.tar.gz
+      tar zxvf trivy_${TRIVY_VERSION:-0.24.4}_Linux-64bit.tar.gz
       # show all vulnerabilities in the logs
       ./trivy image --reset
       for IMAGE_NAME in "proxy" "proxy-init" "webhook"; do

--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -1,10 +1,12 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-iptables:bullseye-v1.1.0
+FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-iptables:bullseye-v1.2.0
 
 # upgrading libssl1.1 due to CVE-2021-3711 and CVE-2021-3712
-# upgrading libgssapi-krb5-2 and libk5crypto3 due to CVE-2021-37750
 # upgrading libgmp10 due to CVE-2021-43618
 # upgrading bsdutils due to CVE-2021-3995 and CVE-2021-3996
-RUN clean-install ca-certificates libssl1.1 libgssapi-krb5-2 libk5crypto3 libgmp10 bsdutils
+# upgrading libc-bin due to CVE-2021-33574, CVE-2022-23218 and CVE-2022-23219
+# upgrading libc6 due to CVE-2021-33574, CVE-2022-23218 and CVE-2022-23219
+# upgrading libsystemd0 and libudev1 due to CVE-2021-3997
+RUN clean-install ca-certificates libssl1.1 libgmp10 bsdutils libc-bin libc6 libsystemd0 libudev1
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh
 # Kubernetes runAsNonRoot requires USER to be numeric


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

- Fixes the following CVEs:
	- CVE-2021-33574
	- CVE-2022-23218 
	- CVE-2022-23219
	- CVE-2021-3997
- Bumps default trivy version to 0.24.4
- Upgrades base image to bullseye-1.2.0

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
