### PR TITLE
chore: upgrade to debian-iptables:bullseye-v1.3.0

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -1,13 +1,7 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-iptables:bullseye-v1.2.0
+FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-iptables:bullseye-v1.3.0
 
-# upgrading libssl1.1 due to CVE-2021-3711 and CVE-2021-3712
-# upgrading libgmp10 due to CVE-2021-43618
-# upgrading bsdutils due to CVE-2021-3995 and CVE-2021-3996
-# upgrading libc-bin due to CVE-2021-33574, CVE-2022-23218 and CVE-2022-23219
-# upgrading libc6 due to CVE-2021-33574, CVE-2022-23218 and CVE-2022-23219
-# upgrading libsystemd0 and libudev1 due to CVE-2021-3997
 # upgrading zlib1g due to CVE-2018-25032
-RUN clean-install ca-certificates libssl1.1 libgmp10 bsdutils libc-bin libc6 libsystemd0 libudev1 zlib1g
+RUN clean-install ca-certificates zlib1g
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh
 # Kubernetes runAsNonRoot requires USER to be numeric


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
