### PR TITLE
chore: change variable name from pod to workload identity

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -20,7 +20,7 @@ var (
 	debug bool
 )
 
-// NewRootCmd returns the root command for Azure Pod Identity.
+// NewRootCmd returns the root command for Azure Workload Identity.
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   rootName,

--- a/pkg/cmd/serviceaccount/phases/create/serviceaccount_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/serviceaccount_test.go
@@ -113,8 +113,8 @@ func TestServiceAccountRun(t *testing.T) {
 	if sa, err = kubeClient.CoreV1().ServiceAccounts("service-account-namespace").Get(context.Background(), "service-account-name", metav1.GetOptions{}); err != nil {
 		t.Errorf("expected service account to be created")
 	}
-	if sa.Labels[webhook.UsePodIdentityLabel] != "true" {
-		t.Errorf("expected service account to have pod identity label but got: %s", sa.Labels[webhook.UsePodIdentityLabel])
+	if sa.Labels[webhook.UseWorkloadIdentityLabel] != "true" {
+		t.Errorf("expected service account to have workload identity label but got: %s", sa.Labels[webhook.UseWorkloadIdentityLabel])
 	}
 	if sa.Annotations[webhook.ClientIDAnnotation] != "aad-application-client-id" {
 		t.Errorf("expected service account to have client id annotation but got: %s", sa.Annotations[webhook.ClientIDAnnotation])

--- a/pkg/kuberneteshelper/serviceaccount.go
+++ b/pkg/kuberneteshelper/serviceaccount.go
@@ -38,7 +38,7 @@ func CreateOrUpdateServiceAccount(ctx context.Context, kubeClient kubernetes.Int
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				webhook.UsePodIdentityLabel: "true",
+				webhook.UseWorkloadIdentityLabel: "true",
 			},
 			Annotations: map[string]string{
 				webhook.ClientIDAnnotation: clientID,

--- a/pkg/kuberneteshelper/serviceaccount_test.go
+++ b/pkg/kuberneteshelper/serviceaccount_test.go
@@ -42,8 +42,8 @@ func TestCreateOrUpdateServiceAccount(t *testing.T) {
 	if sa.Annotations[webhook.ServiceAccountTokenExpiryAnnotation] != "3601" {
 		t.Errorf("CreateServiceAccount() token expiry annotation = %v, want %v", sa.Annotations[webhook.ServiceAccountTokenExpiryAnnotation], "3601")
 	}
-	if sa.Labels[webhook.UsePodIdentityLabel] != "true" {
-		t.Errorf("CreateServiceAccount() usePodIdentity label = %v, want %v", sa.Labels[webhook.UsePodIdentityLabel], "true")
+	if sa.Labels[webhook.UseWorkloadIdentityLabel] != "true" {
+		t.Errorf("CreateServiceAccount() useWorkloadIdentity label = %v, want %v", sa.Labels[webhook.UseWorkloadIdentityLabel], "true")
 	}
 }
 
@@ -69,8 +69,8 @@ func TestCreateOrUpdateServiceAccountDefaultTokenExpiration(t *testing.T) {
 	if _, ok := sa.Annotations[webhook.ServiceAccountTokenExpiryAnnotation]; ok {
 		t.Errorf("CreateServiceAccount() token expiry annotation should not be set")
 	}
-	if sa.Labels[webhook.UsePodIdentityLabel] != "true" {
-		t.Errorf("CreateServiceAccount() usePodIdentity label = %v, want %v", sa.Labels[webhook.UsePodIdentityLabel], "true")
+	if sa.Labels[webhook.UseWorkloadIdentityLabel] != "true" {
+		t.Errorf("CreateServiceAccount() useWorkloadIdentity label = %v, want %v", sa.Labels[webhook.UseWorkloadIdentityLabel], "true")
 	}
 }
 

--- a/pkg/webhook/consts.go
+++ b/pkg/webhook/consts.go
@@ -2,8 +2,8 @@ package webhook
 
 // Annotations and labels defined in service account
 const (
-	// UsePodIdentityLabel represents the service account is to be used for workload identity
-	UsePodIdentityLabel = "azure.workload.identity/use"
+	// UseWorkloadIdentityLabel represents the service account is to be used for workload identity
+	UseWorkloadIdentityLabel = "azure.workload.identity/use"
 	// ClientIDAnnotation represents the clientID to be used with pod
 	ClientIDAnnotation = "azure.workload.identity/client-id"
 	// TenantIDAnnotation represent the tenantID to be used with pod

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -173,7 +173,7 @@ func isServiceAccountAnnotated(sa *corev1.ServiceAccount) bool {
 	if len(sa.Labels) == 0 {
 		return false
 	}
-	_, ok := sa.Labels[UsePodIdentityLabel]
+	_, ok := sa.Labels[UseWorkloadIdentityLabel]
 	return ok
 }
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -43,7 +43,7 @@ func TestIsServiceAccountAnnotated(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sa",
 					Namespace: "default",
-					Labels:    map[string]string{UsePodIdentityLabel: "true"},
+					Labels:    map[string]string{UseWorkloadIdentityLabel: "true"},
 				},
 			},
 			expected: true,
@@ -714,7 +714,7 @@ func TestHandle(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sa",
 			Namespace: "ns1",
-			Labels:    map[string]string{UsePodIdentityLabel: "true"},
+			Labels:    map[string]string{UseWorkloadIdentityLabel: "true"},
 			Annotations: map[string]string{
 				ClientIDAnnotation:                  "clientID",
 				ServiceAccountTokenExpiryAnnotation: "4800",

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -28,7 +28,7 @@ var _ = ginkgo.Describe("Proxy [LinuxOnly] [AKSSoakOnly] [Exclude:Arc]", func() 
 		gomega.Expect(ok).To(gomega.BeTrue(), "APPLICATION_CLIENT_ID must be set")
 		// trust is only set up for 'proxy-test-sa' service account in the default namespace for now
 		const namespace = "default"
-		serviceAccount := createServiceAccount(f.ClientSet, namespace, "proxy-test-sa", map[string]string{webhook.UsePodIdentityLabel: "true"}, map[string]string{webhook.ClientIDAnnotation: clientID})
+		serviceAccount := createServiceAccount(f.ClientSet, namespace, "proxy-test-sa", map[string]string{webhook.UseWorkloadIdentityLabel: "true"}, map[string]string{webhook.ClientIDAnnotation: clientID})
 		defer f.ClientSet.CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), serviceAccount, metav1.DeleteOptions{})
 
 		pod := generatePodWithServiceAccount(

--- a/test/e2e/token_exchange.go
+++ b/test/e2e/token_exchange.go
@@ -36,7 +36,7 @@ var _ = ginkgo.Describe("TokenExchange [AKSSoakOnly] [Exclude:Arc]", func() {
 
 		// trust is only set up for 'pod-identity-sa' service account in the default namespace for now
 		const namespace = "default"
-		serviceAccount := createServiceAccount(f.ClientSet, namespace, "pod-identity-sa", map[string]string{webhook.UsePodIdentityLabel: "true"}, map[string]string{webhook.ClientIDAnnotation: clientID})
+		serviceAccount := createServiceAccount(f.ClientSet, namespace, "pod-identity-sa", map[string]string{webhook.UseWorkloadIdentityLabel: "true"}, map[string]string{webhook.ClientIDAnnotation: clientID})
 		defer f.ClientSet.CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), serviceAccount, metav1.DeleteOptions{})
 
 		pod, err := createPodWithServiceAccount(

--- a/test/e2e/webhook.go
+++ b/test/e2e/webhook.go
@@ -19,7 +19,7 @@ var _ = ginkgo.Describe("Webhook", func() {
 	f := framework.NewDefaultFramework("webhook")
 
 	ginkgo.It("should mutate a pod with a labeled service account", func() {
-		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UsePodIdentityLabel: "true"}, nil)
+		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UseWorkloadIdentityLabel: "true"}, nil)
 		pod, err := createPodWithServiceAccount(
 			f.ClientSet,
 			f.Namespace.Name,
@@ -35,7 +35,7 @@ var _ = ginkgo.Describe("Webhook", func() {
 	})
 
 	ginkgo.It("should mutate the init containers within a pod", func() {
-		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UsePodIdentityLabel: "true"}, nil)
+		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UseWorkloadIdentityLabel: "true"}, nil)
 		if arcCluster {
 			createSecretForArcCluster(f.ClientSet, f.Namespace.Name, serviceAccount)
 		}
@@ -65,14 +65,14 @@ var _ = ginkgo.Describe("Webhook", func() {
 	})
 
 	ginkgo.It("should mutate a deployment pod with a labeled service account", func() {
-		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UsePodIdentityLabel: "true"}, nil)
+		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UseWorkloadIdentityLabel: "true"}, nil)
 		pod := createPodUsingDeploymentWithServiceAccount(f, serviceAccount)
 		validateMutatedPod(f, pod, nil)
 	})
 
 	ginkgo.It(fmt.Sprintf("should not mutate selected containers if the pod has %s annotated", webhook.SkipContainersAnnotation), func() {
 		const skipContainers = busybox1 + ";"
-		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UsePodIdentityLabel: "true"}, nil)
+		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UseWorkloadIdentityLabel: "true"}, nil)
 		pod, err := createPodWithServiceAccount(
 			f.ClientSet,
 			f.Namespace.Name,
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("Webhook", func() {
 		{webhook.ServiceAccountTokenExpiryAnnotation: "invalid"}, // non-numeric value
 	} {
 		ginkgo.It(fmt.Sprintf("should not mutate a pod if '%s: \"%s\"' is annotated to the service account", webhook.ServiceAccountTokenExpiryAnnotation, annotations[webhook.ServiceAccountTokenExpiryAnnotation]), func() {
-			serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UsePodIdentityLabel: "true"}, annotations)
+			serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UseWorkloadIdentityLabel: "true"}, annotations)
 			_, err := createPodWithServiceAccount(
 				f.ClientSet,
 				f.Namespace.Name,
@@ -109,7 +109,7 @@ var _ = ginkgo.Describe("Webhook", func() {
 		})
 
 		ginkgo.It(fmt.Sprintf("should not mutate a pod if '%s: \"%s\"' is annotated to the pod", webhook.ServiceAccountTokenExpiryAnnotation, annotations[webhook.ServiceAccountTokenExpiryAnnotation]), func() {
-			serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UsePodIdentityLabel: "true"}, nil)
+			serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UseWorkloadIdentityLabel: "true"}, nil)
 			_, err := createPodWithServiceAccount(
 				f.ClientSet,
 				f.Namespace.Name,


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
