### PR TITLE
test: check AKS agentpool provisioning state before upgrading

### DIFF
--- a/.pipelines/templates/upgrade.yaml
+++ b/.pipelines/templates/upgrade.yaml
@@ -39,6 +39,18 @@ jobs:
           UPGRADE_VERSION="$(az aks get-upgrades --resource-group ${CLUSTER_NAME} --name ${CLUSTER_NAME} --query "max(controlPlaneProfile.upgrades[?isPreview==null && !(starts_with(kubernetesVersion, '${MINOR_VERSION}'))].kubernetesVersion)" -otsv)"
           echo "Upgrading to Kubernetes ${UPGRADE_VERSION}"
 
+          # Wait 10 minutes in case the agent pool is still in updating state
+          COUNTER=0
+          while [[ ${COUNTER} -lt 10 ]]; do
+            echo "Waiting for the agent pool to be in succeeded provisioning state (attempt ${COUNTER})"
+            if [[ $(az aks show --resource-group ${CLUSTER_NAME} --name ${CLUSTER_NAME} --query 'agentPoolProfiles[0].provisioningState' -otsv) == "Succeeded" ]]; then
+              echo "Agent pool is in succeeded provisioning state"
+              break
+            fi
+            COUNTER=$((COUNTER+1))
+            sleep 60
+          done
+
           az aks upgrade --resource-group "${CLUSTER_NAME}" --name "${CLUSTER_NAME}" --kubernetes-version "${UPGRADE_VERSION}" --yes > /dev/null
         displayName: Upgrade cluster
       - script: make test-e2e


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Fixes #417.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
