### PR TITLE
security: fix CVE-2022-1271

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -1,7 +1,8 @@
 FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-iptables:bullseye-v1.3.0
 
 # upgrading zlib1g due to CVE-2018-25032
-RUN clean-install ca-certificates zlib1g
+# upgrading gzip and liblzma5 due to CVE-2022-1271
+RUN clean-install ca-certificates zlib1g gzip liblzma5
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh
 # Kubernetes runAsNonRoot requires USER to be numeric


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
```bash
e2e/proxy-init:test-linux-amd64 (debian 11.3)
=============================================
Total: 2 (MEDIUM: 0, HIGH: 2, CRITICAL: 0)

+----------+------------------+----------+-------------------+-------------------+--------------------------------------+
| LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |   FIXED VERSION   |                TITLE                 |
+----------+------------------+----------+-------------------+-------------------+--------------------------------------+
| gzip     | CVE-2022-1271    | HIGH     | 1.10-4            | 1.10-4+deb11u1    | gzip: arbitrary-file-write           |
|          |                  |          |                   |                   | vulnerability                        |
|          |                  |          |                   |                   | -->avd.aquasec.com/nvd/cve-2022-1271 |
+----------+                  +          +-------------------+-------------------+                                      +
| liblzma5 |                  |          | 5.2.5-2           | 5.2.5-2.1~deb11u1 |                                      |
|          |                  |          |                   |                   |                                      |
|          |                  |          |                   |                   |                                      |
+----------+------------------+----------+-------------------+-------------------+--------------------------------------+
```

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
