### PR TITLE
chore: use go 1.17 for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,9 @@
 run:
   deadline: 20m
+  # some of the linters don't work correctly with 1.18
+  # xref: https://github.com/golangci/golangci-lint/issues/2649
+  # we are not using generics, so we can pin this to 1.17
+  go: '1.17'
 
 linters:
   disable-all: true


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
follow-up to https://github.com/Azure/azure-workload-identity/pull/429. 

some of the linters don't work correctly with 1.18 (xref: https://github.com/golangci/golangci-lint/issues/2649). Pinning this to 1.17 as we are not using generics.

Running `make lint` will show the list of skipped linters with `v1.45.2` (ref: [CI run](https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/results?buildId=42854&view=logs&jobId=3a559e2a-952e-58d2-b8db-2e604a9266d7&j=3a559e2a-952e-58d2-b8db-2e604a9266d7&t=0dc7cd25-c0cc-5e9c-2964-e6eb48aa3daf)):
```bash
level=warning msg="[linters context] gosimple is disabled because of go1.18. You can track the evolution of the go1.18 support by following the [https://github.com/golangci/golangci-lint/issues/2649."](https://github.com/golangci/golangci-lint/issues/2649.%22)
level=warning msg="[linters context] nilerr is disabled because of go1.18. You can track the evolution of the go1.18 support by following the [https://github.com/golangci/golangci-lint/issues/2649."](https://github.com/golangci/golangci-lint/issues/2649.%22)
level=warning msg="[linters context] staticcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the [https://github.com/golangci/golangci-lint/issues/2649."](https://github.com/golangci/golangci-lint/issues/2649.%22)
level=warning msg="[linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the [https://github.com/golangci/golangci-lint/issues/2649."](https://github.com/golangci/golangci-lint/issues/2649.%22)
level=warning msg="[linters context] unused is disabled because of go1.18. You can track the evolution of the go1.18 support by following the [https://github.com/golangci/golangci-lint/issues/2649."](https://github.com/golangci/golangci-lint/issues/2649.%22)
```

Using go 1.17 will run all linters as expected.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**: