### PR TITLE
feat: add `azwi podidentity` detect subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,3 @@ _artifacts/
 
 # java target from msal-java example
 target/
-
-# test data
-testdata/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ _artifacts/
 
 # java target from msal-java example
 target/
+
+# test data
+testdata/

--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,7 @@ release-manifest: $(KUSTOMIZE)
 	@sed -i -e 's/proxy:[^"]*/proxy:${NEW_VERSION}/' ./test/e2e/e2e_test.go
 	@sed -i -e 's|download/v.*/azure-wi-webhook.yaml|download/${NEW_VERSION}/azure-wi-webhook.yaml|' ./docs/book/src/installation/mutating-admission-webhook.md
 	@sed -i -e 's|azwi@v.*|azwi@${NEW_VERSION}|' ./docs/book/src/installation/azwi.md
+	@sed -i -e 's|imageTag        = .*|imageTag        = "${NEW_VERSION}"|' ./pkg/cmd/podidentity/detect.go
 	$(MAKE) manifests
 
 .PHONY: promote-staging-manifest

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Azure/azure-workload-identity
 go 1.18
 
 require (
+	github.com/Azure/aad-pod-identity v1.8.7
 	github.com/Azure/azure-sdk-for-go v63.4.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.2
 	github.com/Azure/go-autorest/autorest v0.11.27
@@ -43,7 +44,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
-	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
+	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-workload-identity
 go 1.18
 
 require (
-	github.com/Azure/aad-pod-identity v1.8.7
+	github.com/Azure/aad-pod-identity v1.8.8
 	github.com/Azure/azure-sdk-for-go v63.4.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.2
 	github.com/Azure/go-autorest/autorest v0.11.27

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20201218220906-28db891af037/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/Azure/aad-pod-identity v1.8.7 h1:UohLHsclpavv5xFX7SNxh+jGmVpJdKpKpE0Lcwg4674=
+github.com/Azure/aad-pod-identity v1.8.7/go.mod h1:WONFe/GBa5UqyT9RoW9G7iTAdYXyqi9Gan4ZFl3BX64=
 github.com/Azure/azure-sdk-for-go v55.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v63.4.0+incompatible h1:fle3M5Q7vr8auaiPffKyUQmLbvYeqpw30bKU6PrWJFo=
 github.com/Azure/azure-sdk-for-go v63.4.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
@@ -71,8 +73,9 @@ github.com/Azure/go-autorest/autorest/mocks v0.4.2 h1:PGN4EDXnuQbojHbU0UWoNvmu9A
 github.com/Azure/go-autorest/autorest/mocks v0.4.2/go.mod h1:Vy7OitM9Kei0i1Oj+LvyAWMXJHeKH1MVlzFugfVrmyU=
 github.com/Azure/go-autorest/autorest/to v0.4.0 h1:oXVqrxakqqV1UZdSazDOPOLvOIz+XA683u8EctwboHk=
 github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
-github.com/Azure/go-autorest/autorest/validation v0.1.0 h1:ISSNzGUh+ZSzizJWOWzs8bwpXIePbGLW4z/AmUFGH5A=
 github.com/Azure/go-autorest/autorest/validation v0.1.0/go.mod h1:Ha3z/SqBeaalWQvokg3NZAlQTalVMtOIAs1aGK7G6u8=
+github.com/Azure/go-autorest/autorest/validation v0.3.1 h1:AgyqjAd94fwNAoTjl/WQXg4VvFeRFpO+UhNyRXqF1ac=
+github.com/Azure/go-autorest/autorest/validation v0.3.1/go.mod h1:yhLgjC0Wda5DYXl6JAsWyUe4KVNffhoDhG0zVzUMo3E=
 github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+ZtXWSmf4Tg=
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20201218220906-28db891af037/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/Azure/aad-pod-identity v1.8.7 h1:UohLHsclpavv5xFX7SNxh+jGmVpJdKpKpE0Lcwg4674=
-github.com/Azure/aad-pod-identity v1.8.7/go.mod h1:WONFe/GBa5UqyT9RoW9G7iTAdYXyqi9Gan4ZFl3BX64=
+github.com/Azure/aad-pod-identity v1.8.8 h1:Rz1y4ywBnhK5k2DbAM/dH9KUCYFXMI0WaORb6QGZq28=
+github.com/Azure/aad-pod-identity v1.8.8/go.mod h1:WONFe/GBa5UqyT9RoW9G7iTAdYXyqi9Gan4ZFl3BX64=
 github.com/Azure/azure-sdk-for-go v55.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v63.4.0+incompatible h1:fle3M5Q7vr8auaiPffKyUQmLbvYeqpw30bKU6PrWJFo=
 github.com/Azure/azure-sdk-for-go v63.4.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=

--- a/pkg/cmd/podidentity/detect.go
+++ b/pkg/cmd/podidentity/detect.go
@@ -1,13 +1,25 @@
 package podidentity
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-workload-identity/pkg/kuberneteshelper"
+
+	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type detectCmd struct {
-	namespace string
-	outputDir string
+	namespace  string
+	outputDir  string
+	kubeClient client.Client
 }
 
 func newDetectCmd() *cobra.Command {
@@ -18,7 +30,7 @@ func newDetectCmd() *cobra.Command {
 		Short: "Detect the existing aad-pod-identity configuration",
 		Long:  "This command will detect the existing aad-pod-identity configuration and generate a sample configuration file for migration to workload identity",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return detectCmd.validate()
+			return detectCmd.prerun()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return detectCmd.run()
@@ -34,8 +46,10 @@ func newDetectCmd() *cobra.Command {
 	return cmd
 }
 
-func (dc *detectCmd) validate() error {
-	return nil
+func (dc *detectCmd) prerun() error {
+	var err error
+	dc.kubeClient, err = kuberneteshelper.GetKubeClient()
+	return err
 }
 
 func (dc *detectCmd) run() error {
@@ -52,5 +66,131 @@ func (dc *detectCmd) run() error {
 	//    1. If owner using service account, get service account and generate config file with it
 	//    2. If owner doesn't use service account, generate a new service account yaml file with owner name as service account name
 
+	azureIdentityBindings, err := kuberneteshelper.ListAzureIdentityBinding(context.TODO(), dc.kubeClient, dc.namespace)
+	if err != nil {
+		return err
+	}
+	azureIdentities, err := kuberneteshelper.ListAzureIdentity(context.TODO(), dc.kubeClient, dc.namespace)
+	if err != nil {
+		return err
+	}
+
+	labelsToAzureIdentityMap := make(map[string]aadpodv1.AzureIdentity)
+	for _, azureIdentityBinding := range azureIdentityBindings {
+		if azureIdentityBinding.Spec.Selector == "" || azureIdentityBinding.Spec.AzureIdentity == "" {
+			continue
+		}
+		if azureIdentity, ok := azureIdentities[azureIdentityBinding.Spec.AzureIdentity]; ok {
+			labelsToAzureIdentityMap[azureIdentityBinding.Spec.Selector] = azureIdentity
+		}
+	}
+
+	ownerReferences := make(map[metav1.OwnerReference]bool)
+	for selector := range labelsToAzureIdentityMap {
+		log.Debugf("getting pods with selector: %s", selector)
+		pods, err := kuberneteshelper.ListPods(context.TODO(), dc.kubeClient, dc.namespace, map[string]string{"aadpodidbinding": selector})
+		if err != nil {
+			return err
+		}
+		for _, pod := range pods {
+			// for pods created by higher level constructors like deployment, statefulset, cronjob, job, daemonset, replicaset, replicationcontroller
+			// we can get the owner reference with pod.OwnerReferences
+			if len(pod.OwnerReferences) > 0 && pod.OwnerReferences[0].Controller != nil && *pod.OwnerReferences[0].Controller {
+				ownerReferences[pod.OwnerReferences[0]] = true
+			}
+		}
+	}
+
+	for ownerReference := range ownerReferences {
+		log.Debugf("getting owner reference: %s", ownerReference.Name)
+		owner, err := dc.getOwner(ownerReference)
+		if err != nil {
+			return err
+		}
+		serviceAccountName := getServiceAccountName(owner)
+		sa := &corev1.ServiceAccount{}
+		if serviceAccountName == "" || serviceAccountName == "default" {
+			// generate a new service account yaml file with owner name as service account name
+			sa.SetName(owner.GetName())
+			sa.SetNamespace(dc.namespace)
+		} else {
+			// get service account and generate config file with it
+			sa, err = kuberneteshelper.GetServiceAccount(context.TODO(), dc.kubeClient, dc.namespace, serviceAccountName)
+			if err != nil {
+				return err
+			}
+		}
+
+		// generate config file for owner
+
+	}
+
 	return nil
+}
+
+func (dc *detectCmd) getOwner(ownerRef metav1.OwnerReference) (client.Object, error) {
+	switch ownerRef.Kind {
+	case "Deployment":
+		return kuberneteshelper.GetObject(context.TODO(), dc.kubeClient, dc.namespace, ownerRef.Name, &appsv1.Deployment{})
+	case "StatefulSet":
+		return kuberneteshelper.GetObject(context.TODO(), dc.kubeClient, dc.namespace, ownerRef.Name, &appsv1.StatefulSet{})
+	case "CronJob":
+		return kuberneteshelper.GetObject(context.TODO(), dc.kubeClient, dc.namespace, ownerRef.Name, &batchv1.CronJob{})
+	case "Job":
+		return kuberneteshelper.GetObject(context.TODO(), dc.kubeClient, dc.namespace, ownerRef.Name, &batchv1.Job{})
+	case "DaemonSet":
+		return kuberneteshelper.GetObject(context.TODO(), dc.kubeClient, dc.namespace, ownerRef.Name, &appsv1.DaemonSet{})
+	case "ReplicaSet":
+		return kuberneteshelper.GetObject(context.TODO(), dc.kubeClient, dc.namespace, ownerRef.Name, &appsv1.ReplicaSet{})
+	case "ReplicationController":
+		return kuberneteshelper.GetObject(context.TODO(), dc.kubeClient, dc.namespace, ownerRef.Name, &corev1.ReplicationController{})
+	default:
+		return nil, fmt.Errorf("unsupported owner kind: %s", ownerRef.Kind)
+	}
+}
+
+func getServiceAccountName(obj client.Object) string {
+	switch obj.(type) {
+	case *corev1.Pod:
+		return obj.(*corev1.Pod).Spec.ServiceAccountName
+	case *appsv1.Deployment:
+		return obj.(*appsv1.Deployment).Spec.Template.Spec.ServiceAccountName
+	case *appsv1.StatefulSet:
+		return obj.(*appsv1.StatefulSet).Spec.Template.Spec.ServiceAccountName
+	case *appsv1.DaemonSet:
+		return obj.(*appsv1.DaemonSet).Spec.Template.Spec.ServiceAccountName
+	case *appsv1.ReplicaSet:
+		return obj.(*appsv1.ReplicaSet).Spec.Template.Spec.ServiceAccountName
+	case *corev1.ReplicationController:
+		return obj.(*corev1.ReplicationController).Spec.Template.Spec.ServiceAccountName
+	case *batchv1.CronJob:
+		return obj.(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName
+	case *batchv1.Job:
+		return obj.(*batchv1.Job).Spec.Template.Spec.ServiceAccountName
+	default:
+		return ""
+	}
+}
+
+func getContainers(obj client.Object) *[]corev1.Container {
+	switch obj.(type) {
+	case *corev1.Pod:
+		return &obj.(*corev1.Pod).Spec.Containers
+	case *appsv1.Deployment:
+		return &obj.(*appsv1.Deployment).Spec.Template.Spec.Containers
+	case *appsv1.StatefulSet:
+		return &obj.(*appsv1.StatefulSet).Spec.Template.Spec.Containers
+	case *appsv1.DaemonSet:
+		return &obj.(*appsv1.DaemonSet).Spec.Template.Spec.Containers
+	case *appsv1.ReplicaSet:
+		return &obj.(*appsv1.ReplicaSet).Spec.Template.Spec.Containers
+	case *corev1.ReplicationController:
+		return &obj.(*corev1.ReplicationController).Spec.Template.Spec.Containers
+	case *batchv1.CronJob:
+		return &obj.(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers
+	case *batchv1.Job:
+		return &obj.(*batchv1.Job).Spec.Template.Spec.Containers
+	default:
+		return nil
+	}
 }

--- a/pkg/cmd/podidentity/detect.go
+++ b/pkg/cmd/podidentity/detect.go
@@ -1,0 +1,56 @@
+package podidentity
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type detectCmd struct {
+	namespace string
+	outputDir string
+}
+
+func newDetectCmd() *cobra.Command {
+	detectCmd := &detectCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "detect",
+		Short: "Detect the existing aad-pod-identity configuration",
+		Long:  "This command will detect the existing aad-pod-identity configuration and generate a sample configuration file for migration to workload identity",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return detectCmd.validate()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return detectCmd.run()
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&detectCmd.namespace, "namespace", "default", "Namespace to detect the configuration")
+	f.StringVar(&detectCmd.outputDir, "output-dir", "", "Output directory to write the configuration files")
+
+	_ = cmd.MarkFlagRequired("output-dir")
+
+	return cmd
+}
+
+func (dc *detectCmd) validate() error {
+	return nil
+}
+
+func (dc *detectCmd) run() error {
+	log.Debugf("detecting aad-pod-identity configuration in namespace: %s", dc.namespace)
+
+	// Implementing force namespaced mode for now
+	// 1. Get AzureIdentityBinding in the namespace
+	// 2. Get AzureIdentity referenced by AzureIdentityBinding and store in map with aadpodidbinding label value as key and AzureIdentity as value
+	// 3. Get all pods in the namespace that have aadpodidbinding label
+	// 4. For each pod, check if there is an owner reference (deployment, statefulset, cronjob, job, daemonset, replicaset, replicationcontroller)
+	// 5. If there is an owner reference, get the owner reference object and add to map with aadpodidbinding label value as key and owner reference as value
+	// 6. If no owner reference, then assume it's a static pod and add to map with aadpodidbinding label value as key and pod as value
+	// 7. Loop through the first map and generate new config file for each owner reference and service account
+	//    1. If owner using service account, get service account and generate config file with it
+	//    2. If owner doesn't use service account, generate a new service account yaml file with owner name as service account name
+
+	return nil
+}

--- a/pkg/cmd/podidentity/detect_test.go
+++ b/pkg/cmd/podidentity/detect_test.go
@@ -1,0 +1,420 @@
+package podidentity
+
+import (
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/Azure/azure-workload-identity/pkg/cmd/podidentity/k8s"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	trueVal   = true
+	runAsRoot = int64(0)
+
+	expectedProxyInitContainer = corev1.Container{
+		Name:            proxyInitContainerName,
+		Image:           proxyInitImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: &trueVal,
+			RunAsUser:  &runAsRoot,
+			Capabilities: &corev1.Capabilities{
+				Add:  []corev1.Capability{"NET_ADMIN"},
+				Drop: []corev1.Capability{"ALL"},
+			},
+		},
+		Env: []corev1.EnvVar{
+			{
+				Name:  "PROXY_PORT",
+				Value: strconv.Itoa(proxyContainerPort),
+			},
+		},
+	}
+
+	expectedProxyContainer = corev1.Container{
+		Name:            proxyContainerName,
+		Image:           proxyImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Args:            []string{"--log-encoder=json"},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "http",
+				ContainerPort: proxyContainerPort,
+			},
+		},
+	}
+)
+
+func TestAddProxyInitContainers(t *testing.T) {
+	tests := []struct {
+		name             string
+		actualContainers []corev1.Container
+		wantContainers   []corev1.Container
+	}{
+		{
+			name:             "no init containers",
+			actualContainers: nil,
+			wantContainers:   []corev1.Container{expectedProxyInitContainer},
+		},
+		{
+			name: "one init container",
+			actualContainers: []corev1.Container{
+				{
+					Name:  "cont1",
+					Image: "image1",
+				},
+			},
+			wantContainers: []corev1.Container{
+				{
+					Name:  "cont1",
+					Image: "image1",
+				},
+				expectedProxyInitContainer,
+			},
+		},
+		{
+			name: "proxy-init container already exists",
+			actualContainers: []corev1.Container{
+				{
+					Name:  "proxy-init",
+					Image: "mcr.microsoft.com/oss/azure/workload-identity/proxy-init:v0.8.0",
+				},
+			},
+			wantContainers: []corev1.Container{
+				{
+					Name:  "proxy-init",
+					Image: "mcr.microsoft.com/oss/azure/workload-identity/proxy-init:v0.8.0",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotContainers := addProxyInitContainer(tt.actualContainers)
+			if !reflect.DeepEqual(gotContainers, tt.wantContainers) {
+				t.Errorf("addProxyInitContainers() = %v, want %v", gotContainers, tt.wantContainers)
+			}
+		})
+	}
+}
+
+func TestAddProxyContainer(t *testing.T) {
+	tests := []struct {
+		name             string
+		actualContainers []corev1.Container
+		wantContainers   []corev1.Container
+	}{
+		{
+			name:             "no containers",
+			actualContainers: nil,
+			wantContainers:   []corev1.Container{expectedProxyContainer},
+		},
+		{
+			name: "one container",
+			actualContainers: []corev1.Container{
+				{
+					Name:  "cont1",
+					Image: "image1",
+				},
+			},
+			wantContainers: []corev1.Container{
+				{
+					Name:  "cont1",
+					Image: "image1",
+				},
+				expectedProxyContainer,
+			},
+		},
+		{
+			name: "proxy container already exists",
+			actualContainers: []corev1.Container{
+				{
+					Name:  "proxy",
+					Image: "mcr.microsoft.com/oss/azure/workload-identity/proxy:v0.8.0",
+				},
+			},
+			wantContainers: []corev1.Container{
+				{
+					Name:  "proxy",
+					Image: "mcr.microsoft.com/oss/azure/workload-identity/proxy:v0.8.0",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotContainers := addProxyContainer(tt.actualContainers)
+			if !reflect.DeepEqual(gotContainers, tt.wantContainers) {
+				t.Errorf("addProxyContainer() = %v, want %v", gotContainers, tt.wantContainers)
+			}
+		})
+	}
+}
+
+func TestCreateServiceAccountFileError(t *testing.T) {
+	dc := &detectCmd{
+		kubeClient: fake.NewClientBuilder().Build(),
+	}
+	if _, err := dc.createServiceAccountFile("sa", "deployment", "client-id"); err == nil {
+		t.Errorf("createServiceAccountFile() error is nil, want error")
+	}
+}
+
+func TestCreateServiceAccountFile(t *testing.T) {
+	tests := []struct {
+		name                   string
+		saName                 string
+		ownerName              string
+		clientID               string
+		initObjects            []client.Object
+		wantServiceAccountFile string
+	}{
+		{
+			name:                   "using default service account",
+			saName:                 "default",
+			ownerName:              "deployment",
+			clientID:               "client-id",
+			initObjects:            []client.Object{},
+			wantServiceAccountFile: "apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  annotations:\n    azure.workload.identity/client-id: client-id\n  creationTimestamp: null\n  labels:\n    azure.workload.identity/use: \"true\"\n  name: deployment\n  namespace: default\n",
+		},
+		{
+			name:      "using custom service account",
+			saName:    "deployment-sa",
+			ownerName: "deployment",
+			clientID:  "client-id",
+			initObjects: []client.Object{
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deployment-sa",
+						Namespace: "default",
+					},
+				},
+			},
+			wantServiceAccountFile: "apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  annotations:\n    azure.workload.identity/client-id: client-id\n  creationTimestamp: null\n  labels:\n    azure.workload.identity/use: \"true\"\n  name: deployment-sa\n  namespace: default\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outDir, _ := os.MkdirTemp("", "")
+			defer os.RemoveAll(outDir)
+
+			dc := &detectCmd{
+				kubeClient: fake.NewClientBuilder().WithObjects(tt.initObjects...).Build(),
+				namespace:  "default",
+				serializer: json.NewSerializerWithOptions(
+					json.DefaultMetaFactory, scheme, scheme,
+					json.SerializerOptions{
+						Yaml:   true,
+						Pretty: true,
+						Strict: true,
+					},
+				),
+				outputDir: outDir,
+			}
+			if _, err := dc.createServiceAccountFile(tt.saName, tt.ownerName, tt.clientID); err != nil {
+				t.Errorf("createServiceAccountFile() error = %v, want nil", err)
+			}
+
+			saFile := dc.getServiceAccountFileName(tt.ownerName)
+			if _, err := os.Stat(saFile); os.IsNotExist(err) {
+				t.Errorf("createServiceAccountFile() file %s does not exist, want it to exist", saFile)
+			}
+
+			gotServiceAccountFile, err := os.ReadFile(saFile)
+			if err != nil {
+				t.Errorf("createServiceAccountFile() error = %v, want nil", err)
+			}
+			if string(gotServiceAccountFile) != tt.wantServiceAccountFile {
+				t.Errorf("createServiceAccountFile() =\n%v, want %v", string(gotServiceAccountFile), tt.wantServiceAccountFile)
+			}
+		})
+	}
+}
+
+func TestCreateResourceFile(t *testing.T) {
+	testSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sa",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name string
+		obj  client.Object
+	}{
+		{
+			name: "deployment resource",
+			obj: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "container",
+									Image: "image",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "daemon set resource",
+			obj: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "daemon-set",
+					Namespace: "default",
+				},
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "container",
+									Image: "image",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "stateful set resource",
+			obj: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stateful-set",
+					Namespace: "default",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "container",
+									Image: "image",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "job resource",
+			obj: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job",
+					Namespace: "default",
+				},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "container",
+									Image: "image",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "cron job resource",
+			obj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cron-job",
+					Namespace: "default",
+				},
+				Spec: batchv1.CronJobSpec{
+					JobTemplate: batchv1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  "container",
+											Image: "image",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod resource",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container",
+							Image: "image",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outDir, _ := os.MkdirTemp("", "")
+			defer os.RemoveAll(outDir)
+
+			dc := &detectCmd{
+				kubeClient: fake.NewClientBuilder().Build(),
+				namespace:  "default",
+				serializer: json.NewSerializerWithOptions(
+					json.DefaultMetaFactory, scheme, scheme,
+					json.SerializerOptions{
+						Yaml:   true,
+						Pretty: true,
+						Strict: true,
+					},
+				),
+				outputDir: outDir,
+			}
+			localObj := k8s.NewLocalObject(tt.obj)
+			if err := dc.createResourceFile(localObj, testSA); err != nil {
+				t.Errorf("createResourceFile() error = %v, want nil", err)
+			}
+
+			resourceFile := dc.getResourceFileName(localObj)
+			if _, err := os.Stat(resourceFile); os.IsNotExist(err) {
+				t.Errorf("createResourceFile() file %s does not exist, want it to exist", resourceFile)
+			}
+
+			if _, err := os.ReadFile(resourceFile); err != nil {
+				t.Errorf("createResourceFile() error = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/pkg/cmd/podidentity/k8s/cronjob.go
+++ b/pkg/cmd/podidentity/k8s/cronjob.go
@@ -1,0 +1,54 @@
+package k8s
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type cronJobLocalObject struct {
+	client.Object
+}
+
+func newCronJobLocalObject(obj client.Object) LocalObject {
+	return &cronJobLocalObject{
+		Object: obj,
+	}
+}
+
+func (o *cronJobLocalObject) GetServiceAccountName() string {
+	return o.Object.(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName
+}
+
+func (o *cronJobLocalObject) SetServiceAccountName(name string) {
+	o.Object.(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName = name
+}
+
+func (o *cronJobLocalObject) GetContainers() []corev1.Container {
+	return o.Object.(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers
+}
+
+func (o *cronJobLocalObject) SetContainers(containers []corev1.Container) {
+	o.Object.(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers = containers
+}
+
+func (o *cronJobLocalObject) GetInitContainers() []corev1.Container {
+	return o.Object.(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.InitContainers
+}
+
+func (o *cronJobLocalObject) SetInitContainers(containers []corev1.Container) {
+	o.Object.(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec.InitContainers = containers
+}
+
+func (o *cronJobLocalObject) SetGVK() {
+	o.Object.(*batchv1.CronJob).SetGroupVersionKind(schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"})
+}
+
+func (o *cronJobLocalObject) ResetStatus() {
+	o.Object.(*batchv1.CronJob).Status = batchv1.CronJobStatus{}
+}
+
+func (o *cronJobLocalObject) GetObject() client.Object {
+	return o.Object
+}

--- a/pkg/cmd/podidentity/k8s/daemonset.go
+++ b/pkg/cmd/podidentity/k8s/daemonset.go
@@ -1,0 +1,54 @@
+package k8s
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type daemonSetLocalObject struct {
+	client.Object
+}
+
+func newDaemonSetLocalObject(obj client.Object) LocalObject {
+	return &daemonSetLocalObject{
+		Object: obj,
+	}
+}
+
+func (o *daemonSetLocalObject) GetServiceAccountName() string {
+	return o.Object.(*appsv1.DaemonSet).Spec.Template.Spec.ServiceAccountName
+}
+
+func (o *daemonSetLocalObject) SetServiceAccountName(name string) {
+	o.Object.(*appsv1.DaemonSet).Spec.Template.Spec.ServiceAccountName = name
+}
+
+func (o *daemonSetLocalObject) GetContainers() []corev1.Container {
+	return o.Object.(*appsv1.DaemonSet).Spec.Template.Spec.Containers
+}
+
+func (o *daemonSetLocalObject) SetContainers(containers []corev1.Container) {
+	o.Object.(*appsv1.DaemonSet).Spec.Template.Spec.Containers = containers
+}
+
+func (o *daemonSetLocalObject) GetInitContainers() []corev1.Container {
+	return o.Object.(*appsv1.DaemonSet).Spec.Template.Spec.InitContainers
+}
+
+func (o *daemonSetLocalObject) SetInitContainers(containers []corev1.Container) {
+	o.Object.(*appsv1.DaemonSet).Spec.Template.Spec.InitContainers = containers
+}
+
+func (o *daemonSetLocalObject) SetGVK() {
+	o.Object.(*appsv1.DaemonSet).SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"})
+}
+
+func (o *daemonSetLocalObject) ResetStatus() {
+	o.Object.(*appsv1.DaemonSet).Status = appsv1.DaemonSetStatus{}
+}
+
+func (o *daemonSetLocalObject) GetObject() client.Object {
+	return o.Object
+}

--- a/pkg/cmd/podidentity/k8s/deployment.go
+++ b/pkg/cmd/podidentity/k8s/deployment.go
@@ -1,0 +1,54 @@
+package k8s
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type deploymentLocalObject struct {
+	client.Object
+}
+
+func newDeploymentLocalObject(obj client.Object) LocalObject {
+	return &deploymentLocalObject{
+		Object: obj,
+	}
+}
+
+func (o *deploymentLocalObject) GetServiceAccountName() string {
+	return o.Object.(*appsv1.Deployment).Spec.Template.Spec.ServiceAccountName
+}
+
+func (o *deploymentLocalObject) SetServiceAccountName(name string) {
+	o.Object.(*appsv1.Deployment).Spec.Template.Spec.ServiceAccountName = name
+}
+
+func (o *deploymentLocalObject) GetContainers() []corev1.Container {
+	return o.Object.(*appsv1.Deployment).Spec.Template.Spec.Containers
+}
+
+func (o *deploymentLocalObject) SetContainers(containers []corev1.Container) {
+	o.Object.(*appsv1.Deployment).Spec.Template.Spec.Containers = containers
+}
+
+func (o *deploymentLocalObject) GetInitContainers() []corev1.Container {
+	return o.Object.(*appsv1.Deployment).Spec.Template.Spec.InitContainers
+}
+
+func (o *deploymentLocalObject) SetInitContainers(containers []corev1.Container) {
+	o.Object.(*appsv1.Deployment).Spec.Template.Spec.InitContainers = containers
+}
+
+func (o *deploymentLocalObject) SetGVK() {
+	o.Object.(*appsv1.Deployment).SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+}
+
+func (o *deploymentLocalObject) ResetStatus() {
+	o.Object.(*appsv1.Deployment).Status = appsv1.DeploymentStatus{}
+}
+
+func (o *deploymentLocalObject) GetObject() client.Object {
+	return o.Object
+}

--- a/pkg/cmd/podidentity/k8s/job.go
+++ b/pkg/cmd/podidentity/k8s/job.go
@@ -1,0 +1,54 @@
+package k8s
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type jobLocalObject struct {
+	client.Object
+}
+
+func newJobLocalObject(obj client.Object) LocalObject {
+	return &jobLocalObject{
+		Object: obj,
+	}
+}
+
+func (o *jobLocalObject) GetServiceAccountName() string {
+	return o.Object.(*batchv1.Job).Spec.Template.Spec.ServiceAccountName
+}
+
+func (o *jobLocalObject) SetServiceAccountName(name string) {
+	o.Object.(*batchv1.Job).Spec.Template.Spec.ServiceAccountName = name
+}
+
+func (o *jobLocalObject) GetContainers() []corev1.Container {
+	return o.Object.(*batchv1.Job).Spec.Template.Spec.Containers
+}
+
+func (o *jobLocalObject) SetContainers(containers []corev1.Container) {
+	o.Object.(*batchv1.Job).Spec.Template.Spec.Containers = containers
+}
+
+func (o *jobLocalObject) GetInitContainers() []corev1.Container {
+	return o.Object.(*batchv1.Job).Spec.Template.Spec.InitContainers
+}
+
+func (o *jobLocalObject) SetInitContainers(containers []corev1.Container) {
+	o.Object.(*batchv1.Job).Spec.Template.Spec.InitContainers = containers
+}
+
+func (o *jobLocalObject) SetGVK() {
+	o.Object.(*batchv1.Job).SetGroupVersionKind(schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"})
+}
+
+func (o *jobLocalObject) ResetStatus() {
+	o.Object.(*batchv1.Job).Status = batchv1.JobStatus{}
+}
+
+func (o *jobLocalObject) GetObject() client.Object {
+	return o.Object
+}

--- a/pkg/cmd/podidentity/k8s/localobject.go
+++ b/pkg/cmd/podidentity/k8s/localobject.go
@@ -1,0 +1,44 @@
+package k8s
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type LocalObject interface {
+	client.Object
+	GetServiceAccountName() string
+	SetServiceAccountName(name string)
+	GetContainers() []corev1.Container
+	SetContainers(containers []corev1.Container)
+	GetInitContainers() []corev1.Container
+	SetInitContainers(containers []corev1.Container)
+	SetGVK()
+	GetObject() client.Object
+	ResetStatus()
+}
+
+func NewLocalObject(obj client.Object) LocalObject {
+	switch obj.(type) {
+	case *corev1.Pod:
+		return newPodLocalObject(obj)
+	case *appsv1.Deployment:
+		return newDeploymentLocalObject(obj)
+	case *appsv1.StatefulSet:
+		return newStatefulSetLocalObject(obj)
+	case *appsv1.DaemonSet:
+		return newDaemonSetLocalObject(obj)
+	case *appsv1.ReplicaSet:
+		return newReplicaSetLocalObject(obj)
+	case *corev1.ReplicationController:
+		return newReplicationControllerLocalObject(obj)
+	case *batchv1.CronJob:
+		return newCronJobLocalObject(obj)
+	case *batchv1.Job:
+		return newJobLocalObject(obj)
+	default:
+		return nil
+	}
+}

--- a/pkg/cmd/podidentity/k8s/pod.go
+++ b/pkg/cmd/podidentity/k8s/pod.go
@@ -1,0 +1,53 @@
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type podLocalObject struct {
+	client.Object
+}
+
+func newPodLocalObject(obj client.Object) LocalObject {
+	return &podLocalObject{
+		Object: obj,
+	}
+}
+
+func (o *podLocalObject) GetServiceAccountName() string {
+	return o.Object.(*corev1.Pod).Spec.ServiceAccountName
+}
+
+func (o *podLocalObject) SetServiceAccountName(name string) {
+	o.Object.(*corev1.Pod).Spec.ServiceAccountName = name
+}
+
+func (o *podLocalObject) GetContainers() []corev1.Container {
+	return o.Object.(*corev1.Pod).Spec.Containers
+}
+
+func (o *podLocalObject) SetContainers(containers []corev1.Container) {
+	o.Object.(*corev1.Pod).Spec.Containers = containers
+}
+
+func (o *podLocalObject) GetInitContainers() []corev1.Container {
+	return o.Object.(*corev1.Pod).Spec.InitContainers
+}
+
+func (o *podLocalObject) SetInitContainers(containers []corev1.Container) {
+	o.Object.(*corev1.Pod).Spec.InitContainers = containers
+}
+
+func (o *podLocalObject) SetGVK() {
+	o.Object.(*corev1.Pod).SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+}
+
+func (o *podLocalObject) ResetStatus() {
+	o.Object.(*corev1.Pod).Status = corev1.PodStatus{}
+}
+
+func (o *podLocalObject) GetObject() client.Object {
+	return o.Object
+}

--- a/pkg/cmd/podidentity/k8s/replicaset.go
+++ b/pkg/cmd/podidentity/k8s/replicaset.go
@@ -1,0 +1,54 @@
+package k8s
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type replicaSetLocalObject struct {
+	client.Object
+}
+
+func newReplicaSetLocalObject(obj client.Object) LocalObject {
+	return &replicaSetLocalObject{
+		Object: obj,
+	}
+}
+
+func (o *replicaSetLocalObject) GetServiceAccountName() string {
+	return o.Object.(*appsv1.ReplicaSet).Spec.Template.Spec.ServiceAccountName
+}
+
+func (o *replicaSetLocalObject) SetServiceAccountName(name string) {
+	o.Object.(*appsv1.ReplicaSet).Spec.Template.Spec.ServiceAccountName = name
+}
+
+func (o *replicaSetLocalObject) GetContainers() []corev1.Container {
+	return o.Object.(*appsv1.ReplicaSet).Spec.Template.Spec.Containers
+}
+
+func (o *replicaSetLocalObject) SetContainers(containers []corev1.Container) {
+	o.Object.(*appsv1.ReplicaSet).Spec.Template.Spec.Containers = containers
+}
+
+func (o *replicaSetLocalObject) GetInitContainers() []corev1.Container {
+	return o.Object.(*appsv1.ReplicaSet).Spec.Template.Spec.InitContainers
+}
+
+func (o *replicaSetLocalObject) SetInitContainers(containers []corev1.Container) {
+	o.Object.(*appsv1.ReplicaSet).Spec.Template.Spec.InitContainers = containers
+}
+
+func (o *replicaSetLocalObject) SetGVK() {
+	o.Object.(*appsv1.ReplicaSet).SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+}
+
+func (o *replicaSetLocalObject) ResetStatus() {
+	o.Object.(*appsv1.ReplicaSet).Status = appsv1.ReplicaSetStatus{}
+}
+
+func (o *replicaSetLocalObject) GetObject() client.Object {
+	return o.Object
+}

--- a/pkg/cmd/podidentity/k8s/replicationcontroller.go
+++ b/pkg/cmd/podidentity/k8s/replicationcontroller.go
@@ -1,0 +1,53 @@
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type replicationControllerLocalObject struct {
+	client.Object
+}
+
+func newReplicationControllerLocalObject(obj client.Object) LocalObject {
+	return &replicationControllerLocalObject{
+		Object: obj,
+	}
+}
+
+func (o *replicationControllerLocalObject) GetServiceAccountName() string {
+	return o.Object.(*corev1.ReplicationController).Spec.Template.Spec.ServiceAccountName
+}
+
+func (o *replicationControllerLocalObject) SetServiceAccountName(name string) {
+	o.Object.(*corev1.ReplicationController).Spec.Template.Spec.ServiceAccountName = name
+}
+
+func (o *replicationControllerLocalObject) GetContainers() []corev1.Container {
+	return o.Object.(*corev1.ReplicationController).Spec.Template.Spec.Containers
+}
+
+func (o *replicationControllerLocalObject) SetContainers(containers []corev1.Container) {
+	o.Object.(*corev1.ReplicationController).Spec.Template.Spec.Containers = containers
+}
+
+func (o *replicationControllerLocalObject) GetInitContainers() []corev1.Container {
+	return o.Object.(*corev1.ReplicationController).Spec.Template.Spec.InitContainers
+}
+
+func (o *replicationControllerLocalObject) SetInitContainers(containers []corev1.Container) {
+	o.Object.(*corev1.ReplicationController).Spec.Template.Spec.InitContainers = containers
+}
+
+func (o *replicationControllerLocalObject) SetGVK() {
+	o.Object.(*corev1.ReplicationController).SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ReplicationController"})
+}
+
+func (o *replicationControllerLocalObject) ResetStatus() {
+	o.Object.(*corev1.ReplicationController).Status = corev1.ReplicationControllerStatus{}
+}
+
+func (o *replicationControllerLocalObject) GetObject() client.Object {
+	return o.Object
+}

--- a/pkg/cmd/podidentity/k8s/statefulset.go
+++ b/pkg/cmd/podidentity/k8s/statefulset.go
@@ -1,0 +1,54 @@
+package k8s
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type statefulSetLocalObject struct {
+	client.Object
+}
+
+func newStatefulSetLocalObject(obj client.Object) LocalObject {
+	return &statefulSetLocalObject{
+		Object: obj,
+	}
+}
+
+func (o *statefulSetLocalObject) GetServiceAccountName() string {
+	return o.Object.(*appsv1.StatefulSet).Spec.Template.Spec.ServiceAccountName
+}
+
+func (o *statefulSetLocalObject) SetServiceAccountName(name string) {
+	o.Object.(*appsv1.StatefulSet).Spec.Template.Spec.ServiceAccountName = name
+}
+
+func (o *statefulSetLocalObject) GetContainers() []corev1.Container {
+	return o.Object.(*appsv1.StatefulSet).Spec.Template.Spec.Containers
+}
+
+func (o *statefulSetLocalObject) SetContainers(containers []corev1.Container) {
+	o.Object.(*appsv1.StatefulSet).Spec.Template.Spec.Containers = containers
+}
+
+func (o *statefulSetLocalObject) GetInitContainers() []corev1.Container {
+	return o.Object.(*appsv1.StatefulSet).Spec.Template.Spec.InitContainers
+}
+
+func (o *statefulSetLocalObject) SetInitContainers(containers []corev1.Container) {
+	o.Object.(*appsv1.StatefulSet).Spec.Template.Spec.InitContainers = containers
+}
+
+func (o *statefulSetLocalObject) SetGVK() {
+	o.Object.(*appsv1.StatefulSet).SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"})
+}
+
+func (o *statefulSetLocalObject) ResetStatus() {
+	o.Object.(*appsv1.StatefulSet).Status = appsv1.StatefulSetStatus{}
+}
+
+func (o *statefulSetLocalObject) GetObject() client.Object {
+	return o.Object
+}

--- a/pkg/cmd/podidentity/root.go
+++ b/pkg/cmd/podidentity/root.go
@@ -1,0 +1,26 @@
+package podidentity
+
+import "github.com/spf13/cobra"
+
+func NewPodIdentityCmd() *cobra.Command {
+	podIdentityCmd := &cobra.Command{
+		Use:     "podidentity",
+		Short:   "Configuration created for aad-pod-identity",
+		Long:    "Configuration created for aad-pod-identity",
+		Aliases: []string{"pi"},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// run root command pre-run to register the debug flag
+			if cmd.Root() != nil && cmd.Root().PersistentPreRun != nil {
+				cmd.Root().PersistentPreRun(cmd.Root(), args)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Usage()
+		},
+	}
+
+	podIdentityCmd.AddCommand(newDetectCmd())
+
+	return podIdentityCmd
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/Azure/azure-workload-identity/pkg/cmd/jwks"
+	"github.com/Azure/azure-workload-identity/pkg/cmd/podidentity"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/version"
 
@@ -42,6 +43,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(version.NewVersionCmd())
 	cmd.AddCommand(serviceaccount.NewServiceAccountCmd())
 	cmd.AddCommand(jwks.NewJWKSCmd())
+	cmd.AddCommand(podidentity.NewPodIdentityCmd())
 
 	return cmd
 }

--- a/pkg/cmd/serviceaccount/create.go
+++ b/pkg/cmd/serviceaccount/create.go
@@ -17,7 +17,7 @@ import (
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func newCreateCmd(authProvider auth.Provider) *cobra.Command {
@@ -214,6 +214,6 @@ func (c *createData) AzureClient() cloud.Interface {
 }
 
 // KubeClient returns the Kubernetes client.
-func (c *createData) KubeClient() (kubernetes.Interface, error) {
+func (c *createData) KubeClient() (client.Client, error) {
 	return kuberneteshelper.GetKubeClient()
 }

--- a/pkg/cmd/serviceaccount/delete.go
+++ b/pkg/cmd/serviceaccount/delete.go
@@ -15,7 +15,7 @@ import (
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func newDeleteCmd(authProvider auth.Provider) *cobra.Command {
@@ -132,6 +132,6 @@ func (d *deleteData) AzureClient() cloud.Interface {
 }
 
 // KubeClient returns the Kubernetes client.
-func (d *deleteData) KubeClient() (kubernetes.Interface, error) {
+func (d *deleteData) KubeClient() (client.Client, error) {
 	return kuberneteshelper.GetKubeClient()
 }

--- a/pkg/cmd/serviceaccount/phases/create/data.go
+++ b/pkg/cmd/serviceaccount/phases/create/data.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
 
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
-	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateData is the interface to use for create phase.
@@ -63,5 +63,5 @@ type CreateData interface {
 	AzureClient() cloud.Interface
 
 	// KubeClient returns the Kubernetes client.
-	KubeClient() (kubernetes.Interface, error)
+	KubeClient() (client.Client, error)
 }

--- a/pkg/cmd/serviceaccount/phases/create/data_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/data_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 	"github.com/pkg/errors"
-	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type mockCreateData struct {
@@ -28,7 +28,7 @@ type mockCreateData struct {
 	azureScope                    string
 	azureTenantID                 string
 	azureClient                   cloud.Interface
-	kubeClient                    kubernetes.Interface
+	kubeClient                    client.Client
 }
 
 var _ CreateData = &mockCreateData{}
@@ -105,7 +105,7 @@ func (c *mockCreateData) AzureClient() cloud.Interface {
 	return c.azureClient
 }
 
-func (c *mockCreateData) KubeClient() (kubernetes.Interface, error) {
+func (c *mockCreateData) KubeClient() (client.Client, error) {
 	if c.kubeClient == nil {
 		return nil, errors.New("not found")
 	}

--- a/pkg/cmd/serviceaccount/phases/create/serviceaccount.go
+++ b/pkg/cmd/serviceaccount/phases/create/serviceaccount.go
@@ -8,10 +8,10 @@ import (
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 	"github.com/Azure/azure-workload-identity/pkg/kuberneteshelper"
 	"github.com/Azure/azure-workload-identity/pkg/webhook"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -19,7 +19,7 @@ const (
 )
 
 type serviceAccountPhase struct {
-	kubeClient kubernetes.Interface
+	kubeClient client.Client
 }
 
 // NewServiceAccountPhase creates a new phase to create a Kubernetes service account

--- a/pkg/cmd/serviceaccount/phases/delete/data.go
+++ b/pkg/cmd/serviceaccount/phases/delete/data.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
 
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
-	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DeleteData is the interface to use for create phase.
@@ -37,5 +37,5 @@ type DeleteData interface {
 	AzureClient() cloud.Interface
 
 	// KubeClient returns the Kubernetes client.
-	KubeClient() (kubernetes.Interface, error)
+	KubeClient() (client.Client, error)
 }

--- a/pkg/cmd/serviceaccount/phases/delete/data_test.go
+++ b/pkg/cmd/serviceaccount/phases/delete/data_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 	"github.com/pkg/errors"
-	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type mockDeleteData struct {
@@ -20,7 +20,7 @@ type mockDeleteData struct {
 	aadApplicationObjectID  string
 	roleAssignmentID        string
 	azureClient             cloud.Interface
-	kubeClient              kubernetes.Interface
+	kubeClient              client.Client
 }
 
 var _ DeleteData = &mockDeleteData{}
@@ -63,7 +63,7 @@ func (d *mockDeleteData) AzureClient() cloud.Interface {
 	return d.azureClient
 }
 
-func (d *mockDeleteData) KubeClient() (kubernetes.Interface, error) {
+func (d *mockDeleteData) KubeClient() (client.Client, error) {
 	if d.kubeClient == nil {
 		return nil, errors.New("not found")
 	}

--- a/pkg/cmd/serviceaccount/phases/delete/serviceaccount.go
+++ b/pkg/cmd/serviceaccount/phases/delete/serviceaccount.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -18,7 +18,7 @@ const (
 )
 
 type serviceAccountPhase struct {
-	kubeClient kubernetes.Interface
+	kubeClient client.Client
 }
 
 // NewServiceAccountPhase creates a new phase to delete the Kubernetes service account

--- a/pkg/kuberneteshelper/azureidentity.go
+++ b/pkg/kuberneteshelper/azureidentity.go
@@ -1,0 +1,22 @@
+package kuberneteshelper
+
+import (
+	"context"
+
+	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ListAzureIdentity(ctx context.Context, kubeClient client.Client, namespace string) (map[string]aadpodv1.AzureIdentity, error) {
+	list := &aadpodv1.AzureIdentityList{}
+	if err := kubeClient.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+
+	azureIdentityMap := make(map[string]aadpodv1.AzureIdentity)
+	for _, identity := range list.Items {
+		azureIdentityMap[identity.Name] = identity
+	}
+
+	return azureIdentityMap, nil
+}

--- a/pkg/kuberneteshelper/azureidentity.go
+++ b/pkg/kuberneteshelper/azureidentity.go
@@ -8,16 +8,11 @@ import (
 )
 
 // ListAzureIdentity returns a list of AzureIdentity
-func ListAzureIdentity(ctx context.Context, kubeClient client.Client, namespace string) (map[string]aadpodv1.AzureIdentity, error) {
+func ListAzureIdentity(ctx context.Context, kubeClient client.Client, namespace string) ([]aadpodv1.AzureIdentity, error) {
 	list := &aadpodv1.AzureIdentityList{}
 	if err := kubeClient.List(ctx, list, client.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
 
-	azureIdentityMap := make(map[string]aadpodv1.AzureIdentity)
-	for _, identity := range list.Items {
-		azureIdentityMap[identity.Name] = identity
-	}
-
-	return azureIdentityMap, nil
+	return list.Items, nil
 }

--- a/pkg/kuberneteshelper/azureidentity.go
+++ b/pkg/kuberneteshelper/azureidentity.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ListAzureIdentity returns a list of AzureIdentity
 func ListAzureIdentity(ctx context.Context, kubeClient client.Client, namespace string) (map[string]aadpodv1.AzureIdentity, error) {
 	list := &aadpodv1.AzureIdentityList{}
 	if err := kubeClient.List(ctx, list, client.InNamespace(namespace)); err != nil {

--- a/pkg/kuberneteshelper/azureidentitybinding.go
+++ b/pkg/kuberneteshelper/azureidentitybinding.go
@@ -26,17 +26,12 @@ func (a azureIdentityBindings) Less(i, j int) bool {
 }
 
 // ListAzureIdentityBinding returns a list of AzureIdentityBinding
-func ListAzureIdentityBinding(ctx context.Context, kubeClient client.Client, namespace string) (map[string]aadpodv1.AzureIdentityBinding, error) {
+func ListAzureIdentityBinding(ctx context.Context, kubeClient client.Client, namespace string) ([]aadpodv1.AzureIdentityBinding, error) {
 	list := &aadpodv1.AzureIdentityBindingList{}
 	if err := kubeClient.List(ctx, list, client.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
 
 	sort.Sort(azureIdentityBindings(list.Items))
-	azureIdentityBindingMap := make(map[string]aadpodv1.AzureIdentityBinding)
-	for _, binding := range list.Items {
-		azureIdentityBindingMap[binding.Name] = binding
-	}
-
-	return azureIdentityBindingMap, nil
+	return list.Items, nil
 }

--- a/pkg/kuberneteshelper/azureidentitybinding.go
+++ b/pkg/kuberneteshelper/azureidentitybinding.go
@@ -7,6 +7,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ListAzureIdentityBinding(ctx context.Context, kubeClient client.Client, namespace string) map[string]aadpodv1.AzureIdentityBinding {
-	return nil
+// ListAzureIdentityBinding returns a list of AzureIdentityBinding
+func ListAzureIdentityBinding(ctx context.Context, kubeClient client.Client, namespace string) (map[string]aadpodv1.AzureIdentityBinding, error) {
+	list := &aadpodv1.AzureIdentityBindingList{}
+	if err := kubeClient.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+
+	azureIdentityBindingMap := make(map[string]aadpodv1.AzureIdentityBinding)
+	for _, binding := range list.Items {
+		azureIdentityBindingMap[binding.Name] = binding
+	}
+
+	return azureIdentityBindingMap, nil
 }

--- a/pkg/kuberneteshelper/azureidentitybinding.go
+++ b/pkg/kuberneteshelper/azureidentitybinding.go
@@ -1,0 +1,12 @@
+package kuberneteshelper
+
+import (
+	"context"
+
+	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ListAzureIdentityBinding(ctx context.Context, kubeClient client.Client, namespace string) map[string]aadpodv1.AzureIdentityBinding {
+	return nil
+}

--- a/pkg/kuberneteshelper/azureidentitybinding.go
+++ b/pkg/kuberneteshelper/azureidentitybinding.go
@@ -2,10 +2,28 @@ package kuberneteshelper
 
 import (
 	"context"
+	"sort"
 
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+type azureIdentityBindings []aadpodv1.AzureIdentityBinding
+
+func (a azureIdentityBindings) Len() int {
+	return len(a)
+}
+
+func (a azureIdentityBindings) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a azureIdentityBindings) Less(i, j int) bool {
+	if a[i].Namespace == a[j].Namespace {
+		return a[i].Name < a[j].Name
+	}
+	return a[i].Namespace < a[j].Namespace
+}
 
 // ListAzureIdentityBinding returns a list of AzureIdentityBinding
 func ListAzureIdentityBinding(ctx context.Context, kubeClient client.Client, namespace string) (map[string]aadpodv1.AzureIdentityBinding, error) {
@@ -14,6 +32,7 @@ func ListAzureIdentityBinding(ctx context.Context, kubeClient client.Client, nam
 		return nil, err
 	}
 
+	sort.Sort(azureIdentityBindings(list.Items))
 	azureIdentityBindingMap := make(map[string]aadpodv1.AzureIdentityBinding)
 	for _, binding := range list.Items {
 		azureIdentityBindingMap[binding.Name] = binding

--- a/pkg/kuberneteshelper/azureidentitybinding_test.go
+++ b/pkg/kuberneteshelper/azureidentitybinding_test.go
@@ -1,0 +1,69 @@
+package kuberneteshelper
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSort(t *testing.T) {
+	slice := []aadpodv1.AzureIdentityBinding{{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test2",
+			Namespace: "test",
+		},
+	}, {
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test1",
+			Namespace: "default",
+		},
+	}, {
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test3",
+			Namespace: "default",
+		},
+	}, {
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test1",
+			Namespace: "test",
+		},
+	}, {
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test2",
+			Namespace: "default",
+		},
+	}}
+	expected := []aadpodv1.AzureIdentityBinding{{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test1",
+			Namespace: "default",
+		},
+	}, {
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test2",
+			Namespace: "default",
+		},
+	}, {
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test3",
+			Namespace: "default",
+		},
+	}, {
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test1",
+			Namespace: "test",
+		},
+	}, {
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test2",
+			Namespace: "test",
+		},
+	}}
+	sort.Sort(azureIdentityBindings(slice))
+	if !reflect.DeepEqual(slice, expected) {
+		t.Errorf("expected %v, got %v", expected, slice)
+	}
+}

--- a/pkg/kuberneteshelper/client.go
+++ b/pkg/kuberneteshelper/client.go
@@ -3,10 +3,35 @@ package kuberneteshelper
 import (
 	"context"
 
+	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	// Add aadpodidentity v1 to the scheme.
+	aadPodIdentityGroupVersion := schema.GroupVersion{Group: aadpodv1.GroupName, Version: "v1"}
+	scheme.AddKnownTypes(aadPodIdentityGroupVersion,
+		&aadpodv1.AzureIdentity{},
+		&aadpodv1.AzureIdentityList{},
+		&aadpodv1.AzureIdentityBinding{},
+		&aadpodv1.AzureIdentityBindingList{},
+		&aadpodv1.AzurePodIdentityException{},
+		&aadpodv1.AzurePodIdentityExceptionList{},
+	)
+	metav1.AddToGroupVersion(scheme, aadPodIdentityGroupVersion)
+}
 
 // GetKubeConfig returns the kubeconfig
 func GetKubeConfig() (*rest.Config, error) {
@@ -20,7 +45,7 @@ func GetKubeClient() (client.Client, error) {
 		return nil, err
 	}
 
-	return client.New(kubeConfig, client.Options{})
+	return client.New(kubeConfig, client.Options{Scheme: scheme})
 }
 
 // GetObject returns an object from the Kubernetes cluster.

--- a/pkg/kuberneteshelper/client.go
+++ b/pkg/kuberneteshelper/client.go
@@ -1,6 +1,8 @@
 package kuberneteshelper
 
 import (
+	"context"
+
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,4 +21,14 @@ func GetKubeClient() (client.Client, error) {
 	}
 
 	return client.New(kubeConfig, client.Options{})
+}
+
+// GetObject returns an object from the Kubernetes cluster.
+func GetObject(ctx context.Context, kubeClient client.Client, namespace string, name string, obj client.Object) (client.Object, error) {
+	err := kubeClient.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, obj)
+
+	return obj, err
 }

--- a/pkg/kuberneteshelper/client.go
+++ b/pkg/kuberneteshelper/client.go
@@ -1,0 +1,22 @@
+package kuberneteshelper
+
+import (
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetKubeConfig returns the kubeconfig
+func GetKubeConfig() (*rest.Config, error) {
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).ClientConfig()
+}
+
+// GetKubeClient returns a Kubernetes clientset.
+func GetKubeClient() (client.Client, error) {
+	kubeConfig, err := GetKubeConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.New(kubeConfig, client.Options{})
+}

--- a/pkg/kuberneteshelper/client.go
+++ b/pkg/kuberneteshelper/client.go
@@ -27,8 +27,6 @@ func init() {
 		&aadpodv1.AzureIdentityList{},
 		&aadpodv1.AzureIdentityBinding{},
 		&aadpodv1.AzureIdentityBindingList{},
-		&aadpodv1.AzurePodIdentityException{},
-		&aadpodv1.AzurePodIdentityExceptionList{},
 	)
 	metav1.AddToGroupVersion(scheme, aadPodIdentityGroupVersion)
 }

--- a/pkg/kuberneteshelper/pod.go
+++ b/pkg/kuberneteshelper/pod.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ListPods returns a list of Pods in the given namespace that match the given label selector
 func ListPods(ctx context.Context, kubeClient client.Client, namespace string, labels map[string]string) (map[string]corev1.Pod, error) {
 	list := &corev1.PodList{}
 	if err := kubeClient.List(ctx, list, client.InNamespace(namespace), client.MatchingLabels(labels)); err != nil {

--- a/pkg/kuberneteshelper/pod.go
+++ b/pkg/kuberneteshelper/pod.go
@@ -1,0 +1,22 @@
+package kuberneteshelper
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ListPods(ctx context.Context, kubeClient client.Client, namespace string, labels map[string]string) (map[string]corev1.Pod, error) {
+	list := &corev1.PodList{}
+	if err := kubeClient.List(ctx, list, client.InNamespace(namespace), client.MatchingLabels(labels)); err != nil {
+		return nil, err
+	}
+
+	podMap := make(map[string]corev1.Pod)
+	for _, pod := range list.Items {
+		podMap[pod.Name] = pod
+	}
+
+	return podMap, nil
+}

--- a/pkg/kuberneteshelper/serviceaccount.go
+++ b/pkg/kuberneteshelper/serviceaccount.go
@@ -10,29 +10,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// GetKubeConfig returns the kubeconfig
-func GetKubeConfig() (*rest.Config, error) {
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).ClientConfig()
-}
-
-// GetKubeClient returns a Kubernetes clientset.
-func GetKubeClient() (kubernetes.Interface, error) {
-	kubeConfig, err := GetKubeConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	return kubernetes.NewForConfigOrDie(kubeConfig), nil
-}
 
 // Create ServiceAccount in the cluster
 // If the ServiceAccount already exists, error is returned
-func CreateOrUpdateServiceAccount(ctx context.Context, kubeClient kubernetes.Interface, namespace, name, clientID, tenantID string, tokenExpiration time.Duration) error {
+func CreateOrUpdateServiceAccount(ctx context.Context, kubeClient client.Client, namespace, name, clientID, tenantID string, tokenExpiration time.Duration) error {
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -52,16 +35,18 @@ func CreateOrUpdateServiceAccount(ctx context.Context, kubeClient kubernetes.Int
 		sa.ObjectMeta.Annotations[webhook.ServiceAccountTokenExpiryAnnotation] = fmt.Sprintf("%.0f", tokenExpiration.Round(time.Second).Seconds())
 	}
 
-	serviceAccount, err := kubeClient.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{})
+	err := kubeClient.Create(ctx, sa)
 	if apierrors.IsAlreadyExists(err) {
-		// Update the existing service account
-		sa.ObjectMeta.ResourceVersion = serviceAccount.ObjectMeta.ResourceVersion
-		_, err = kubeClient.CoreV1().ServiceAccounts(namespace).Update(ctx, sa, metav1.UpdateOptions{})
+		err = kubeClient.Update(ctx, sa)
 	}
 	return err
 }
 
 // Delete ServiceAccount in the cluster
-func DeleteServiceAccount(ctx context.Context, kubeClient kubernetes.Interface, namespace, name string) error {
-	return kubeClient.CoreV1().ServiceAccounts(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+func DeleteServiceAccount(ctx context.Context, kubeClient client.Client, namespace, name string) error {
+	sa := &corev1.ServiceAccount{}
+	if err := kubeClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, sa); err != nil {
+		return err
+	}
+	return kubeClient.Delete(ctx, sa)
 }

--- a/pkg/kuberneteshelper/serviceaccount.go
+++ b/pkg/kuberneteshelper/serviceaccount.go
@@ -50,3 +50,10 @@ func DeleteServiceAccount(ctx context.Context, kubeClient client.Client, namespa
 	}
 	return kubeClient.Delete(ctx, sa)
 }
+
+// Get ServiceAccount in the cluster
+func GetServiceAccount(ctx context.Context, kubeClient client.Client, namespace, name string) (*corev1.ServiceAccount, error) {
+	sa := &corev1.ServiceAccount{}
+	kubeClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, sa)
+	return sa, nil
+}

--- a/pkg/kuberneteshelper/serviceaccount.go
+++ b/pkg/kuberneteshelper/serviceaccount.go
@@ -54,6 +54,6 @@ func DeleteServiceAccount(ctx context.Context, kubeClient client.Client, namespa
 // Get ServiceAccount in the cluster
 func GetServiceAccount(ctx context.Context, kubeClient client.Client, namespace, name string) (*corev1.ServiceAccount, error) {
 	sa := &corev1.ServiceAccount{}
-	kubeClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, sa)
-	return sa, nil
+	err := kubeClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, sa)
+	return sa, err
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Adds `azwi podidentity detect` subcommand to detect existing pod identity configuration in a namespace and generate
  1. YAML for resource with proxy sidecar and proxy-init init container
  2. YAML for service account with client-id annotated based on clientID in `AzureIdentity`
    - If the resource is using default service account, we generate a new service account yaml spec

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/391

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
