### PR TITLE
fix: use debian11 in Dockerfile build image

### DIFF
--- a/examples/msal-python/Dockerfile
+++ b/examples/msal-python/Dockerfile
@@ -1,10 +1,10 @@
 # ref: https://github.com/GoogleContainerTools/distroless/blob/main/examples/python3-requirements/Dockerfile
 
-FROM debian:buster-slim AS build
+FROM debian:11-slim AS build
 RUN apt-get update && \
     apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
     python3 -m venv /venv && \
-    /venv/bin/pip install --upgrade pip
+    /venv/bin/pip install --upgrade pip setuptools wheel
 
 # Build the virtualenv as a separate step: Only re-execute this step when requirements.txt changes
 FROM build AS build-venv


### PR DESCRIPTION
**Reason for Change**:

Updating the image to use Debian 11.

When running the quick-start Python example the following error occurs.

```
$ kubectl logs quick-start
Traceback (most recent call last):
  File "/app/main.py", line 4, in <module>
    from azure.keyvault.secrets import SecretClient
ModuleNotFoundError: No module named 'azure'
```

The build base image is not the same as the runtime one. Build is buster 10 and runtime is bullseye 11.

Debian has already been bumped in the [original reference code](https://github.com/GoogleContainerTools/distroless/commit/d4d6e705d769eb21bb2a020bb096d0bc624e1d57), and that incidentally fixes the issue as well.

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**: #436

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [x] yes - The existing code already has a reference to the original author.
- [ ] no
