### PR TITLE
security: fix CVE-2022-1664

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -3,7 +3,8 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-ipt
 # upgrading zlib1g due to CVE-2018-25032
 # upgrading gzip and liblzma5 due to CVE-2022-1271
 # upgrading libssl1.1 due to CVE-2022-1292
-RUN clean-install ca-certificates zlib1g gzip liblzma5 libssl1.1
+# upgrading dpkg due to CVE-2022-1664
+RUN clean-install ca-certificates zlib1g gzip liblzma5 libssl1.1 dpkg
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh
 # Kubernetes runAsNonRoot requires USER to be numeric


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
```bash
e2e/proxy-init:test-linux-amd64 (debian 11.3)
=============================================
Total: 1 (MEDIUM: 1, HIGH: 0, CRITICAL: 0)

+---------+------------------+----------+-------------------+---------------+--------------------------------------+
| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                TITLE                 |
+---------+------------------+----------+-------------------+---------------+--------------------------------------+
| dpkg    | CVE-2022-1664    | MEDIUM   | 1.20.9            | 1.20.10       | Dpkg::Source::Archive in             |
|         |                  |          |                   |               | dpkg, the Debian package             |
|         |                  |          |                   |               | management system, b ...             |
|         |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-1664 |
+---------+------------------+----------+-------------------+---------------+--------------------------------------+
```

ref: https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/results?buildId=45687&view=logs&jobId=50e5c204-a982-5a63-4824-cf22f1b24a4e&j=50e5c204-a982-5a63-4824-cf22f1b24a4e&t=94cd4644-8683-57bb-f7f8-715cbe70e34e

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
