### PR TITLE
fix: use `id` instead of `objectId` for app object id

### DIFF
--- a/.github/workflows/azwi-e2e.yaml
+++ b/.github/workflows/azwi-e2e.yaml
@@ -78,7 +78,7 @@ jobs:
           cat sa.yaml | grep "azure.workload.identity/tenant-id: ${AZURE_TENANT_ID}"
 
           # get the federated identity
-          APPLICATION_OBJECT_ID="$(az ad app show --id "${APPLICATION_CLIENT_ID}" --query objectId -otsv)"
+          APPLICATION_OBJECT_ID="$(az ad app show --id "${APPLICATION_CLIENT_ID}" --query id -otsv)"
           az rest --method GET --uri "https://graph.microsoft.com/beta/applications/${APPLICATION_OBJECT_ID}/federatedIdentityCredentials"
       - name: Cleanup
         if: ${{ always() }}

--- a/docs/book/src/known-issues.md
+++ b/docs/book/src/known-issues.md
@@ -49,8 +49,8 @@ In the case of service principal, you will have to grant the `Application.ReadWr
 
 ```bash
 # get the app role ID of `Application.ReadWrite.All`
-APPLICATION_OBJECT_ID="$(az ad app show --id ${APPLICATION_CLIENT_ID} --query objectId -otsv)"
-GRAPH_RESOURCE_ID="$(az ad sp list --display-name "Microsoft Graph" --query '[0].objectId' -otsv)"
+APPLICATION_OBJECT_ID="$(az ad app show --id ${APPLICATION_CLIENT_ID} --query id -otsv)"
+GRAPH_RESOURCE_ID="$(az ad sp list --display-name "Microsoft Graph" --query '[0].id' -otsv)"
 APPLICATION_READWRITE_ALL_ID="$(az ad sp list --display-name "Microsoft Graph" --query "[0].appRoles[?value=='Application.ReadWrite.All' && contains(allowedMemberTypes, 'Application')].id" --output tsv)"
 
 URI="https://graph.microsoft.com/v1.0/servicePrincipals/${APPLICATION_OBJECT_ID}/appRoleAssignments"

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -198,7 +198,7 @@ Login to [Azure Cloud Shell][8] and run the following commands:
 
 ```bash
 # Get the object ID of the AAD application
-export APPLICATION_OBJECT_ID="$(az ad app show --id ${APPLICATION_CLIENT_ID} --query objectId -otsv)"
+export APPLICATION_OBJECT_ID="$(az ad app show --id ${APPLICATION_CLIENT_ID} --query id -otsv)"
 ```
 
 Add the federated identity credential:

--- a/docs/book/src/topics/federated-identity-credential.md
+++ b/docs/book/src/topics/federated-identity-credential.md
@@ -46,7 +46,7 @@ To create a federated identity credential, login to [Azure Cloud Shell][1] and r
 ```bash
 # Get the client and object ID of the AAD application
 export APPLICATION_CLIENT_ID="$(az ad sp list --display-name "${APPLICATION_NAME}" --query '[0].appId' -otsv)"
-export APPLICATION_OBJECT_ID="$(az ad app show --id "${APPLICATION_CLIENT_ID}" --query objectId -otsv)"
+export APPLICATION_OBJECT_ID="$(az ad app show --id "${APPLICATION_CLIENT_ID}" --query id -otsv)"
 
 cat <<EOF > body.json
 {


### PR DESCRIPTION

Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
`azwi_e2e` has been failing because the `APPLICATION_OBJECT_ID` is empty: https://github.com/Azure/azure-workload-identity/runs/6716352232?check_suite_focus=true. The application object id is now in `id` parameter and there is no
`objectId` field in the 'az ad app show' response (xref: https://docs.microsoft.com/en-us/cli/azure/microsoft-graph-migration#breaking-changes). This change will fix the azwi e2e CI failure. Also, updating all the references in the docs.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
