### PR TITLE
feat: allow setting `azure.workload.identity/use` in annotations

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -250,12 +250,11 @@ func (m *podMutator) injectProxySidecarContainer(containers []corev1.Container, 
 
 // isServiceAccountAnnotated checks if the service account has been annotated
 // to use with workload identity
+// "azure.workload.identity/use" needs to be available either in annotations or labels
 func isServiceAccountAnnotated(sa *corev1.ServiceAccount) bool {
-	if len(sa.Labels) == 0 {
-		return false
-	}
-	_, ok := sa.Labels[UseWorkloadIdentityLabel]
-	return ok
+	_, isLabeled := sa.Labels[UseWorkloadIdentityLabel]
+	_, isAnnotated := sa.Annotations[UseWorkloadIdentityLabel]
+	return isLabeled || isAnnotated
 }
 
 func shouldInjectProxySidecar(pod *corev1.Pod) bool {

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -31,7 +31,7 @@ func TestIsServiceAccountAnnotated(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "service account not annotated",
+			name: "service account not labeled",
 			sa: &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sa",
@@ -41,12 +41,23 @@ func TestIsServiceAccountAnnotated(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "service account is annotated with azure.workload.identity/use=true",
+			name: "service account is labeled with azure.workload.identity/use=true",
 			sa: &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sa",
 					Namespace: "default",
 					Labels:    map[string]string{UseWorkloadIdentityLabel: "true"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "service account is annotated with azure.workload.identity/use=true",
+			sa: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "sa",
+					Namespace:   "default",
+					Annotations: map[string]string{UseWorkloadIdentityLabel: "true"},
 				},
 			},
 			expected: true,

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -93,7 +93,7 @@ test_helm_chart() {
     --wait
   poll_webhook_readiness
   # TODO(chewong): remove GINKGO_SKIP once the helm chart is updated to use v0.11.0.
-  GINKGO_SKIP="Proxy|should mutate a deployment pod with a annotated service account" make test-e2e-run
+  GINKGO_SKIP="Proxy|should mutate a deployment pod with an annotated service account" make test-e2e-run
 
   ${HELM} upgrade --install workload-identity-webhook "${REPO_ROOT}/manifest_staging/charts/workload-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/workload-identity/webhook}" \

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -93,7 +93,7 @@ test_helm_chart() {
     --wait
   poll_webhook_readiness
   # TODO(chewong): remove GINKGO_SKIP once the helm chart is updated to use v0.11.0.
-  GINKGO_SKIP="Proxy" make test-e2e-run
+  GINKGO_SKIP="Proxy|should mutate a deployment pod with a annotated service account" make test-e2e-run
 
   ${HELM} upgrade --install workload-identity-webhook "${REPO_ROOT}/manifest_staging/charts/workload-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/workload-identity/webhook}" \

--- a/test/e2e/webhook.go
+++ b/test/e2e/webhook.go
@@ -84,6 +84,12 @@ var _ = ginkgo.Describe("Webhook", func() {
 		validateMutatedPod(f, pod, nil)
 	})
 
+	ginkgo.It("should mutate a deployment pod with a annotated service account", func() {
+		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", nil, map[string]string{webhook.UseWorkloadIdentityLabel: "true"})
+		pod := createPodUsingDeploymentWithServiceAccount(f, serviceAccount)
+		validateMutatedPod(f, pod, nil)
+	})
+
 	ginkgo.It(fmt.Sprintf("should not mutate selected containers if the pod has %s annotated", webhook.SkipContainersAnnotation), func() {
 		const skipContainers = busybox1 + ";"
 		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{webhook.UseWorkloadIdentityLabel: "true"}, nil)

--- a/test/e2e/webhook.go
+++ b/test/e2e/webhook.go
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("Webhook", func() {
 		validateMutatedPod(f, pod, nil)
 	})
 
-	ginkgo.It("should mutate a deployment pod with a annotated service account", func() {
+	ginkgo.It("should mutate a deployment pod with an annotated service account", func() {
 		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", nil, map[string]string{webhook.UseWorkloadIdentityLabel: "true"})
 		pod := createPodUsingDeploymentWithServiceAccount(f, serviceAccount)
 		validateMutatedPod(f, pod, nil)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
-  Allow setting `azure.workload.identity/use` in annotations in addition to labels

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #473 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
- I'm thinking of updating the docs after `v0.11.0` release