### PR TITLE
fix: --aad-appliction-name arg listed twice

### DIFF
--- a/docs/book/src/topics/federated-identity-credential.md
+++ b/docs/book/src/topics/federated-identity-credential.md
@@ -25,7 +25,7 @@ To create a federated identity credential:
 azwi serviceaccount create phase federated-identity \
   --aad-application-name "${APPLICATION_NAME}" \
   --service-account-namespace "${SERVICE_ACCOUNT_NAMESPACE}" \
-  --aad-application-name "${SERVICE_ACCOUNT_NAME}" \
+  --service-account-name "${SERVICE_ACCOUNT_NAME}" \
   --service-account-issuer-url "${SERVICE_ACCOUNT_ISSUER}"
 ```
 
@@ -35,7 +35,7 @@ To delete a federated identity credential:
 azwi serviceaccount delete phase federated-identity \
   --aad-application-name "${APPLICATION_NAME}" \
   --service-account-namespace "${SERVICE_ACCOUNT_NAMESPACE}" \
-  --aad-application-name "${SERVICE_ACCOUNT_NAME}" \
+  --service-account-name "${SERVICE_ACCOUNT_NAME}" \
   --service-account-issuer-url "${SERVICE_ACCOUNT_ISSUER}"
 ```
 


### PR DESCRIPTION
Looks like a copy/paste error.

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [x] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
