### PR TITLE
test: remove GINKGO_SKIP in upgrade tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,9 +319,7 @@ GINKGO_ARGS ?= -focus="$(GINKGO_FOCUS)" -skip="$(GINKGO_SKIP)" -nodes=$(GINKGO_N
 KUBECONFIG ?= $(HOME)/.kube/config
 E2E_ARGS := -kubeconfig=$(KUBECONFIG) -report-dir=$(PWD)/_artifacts \
 				 -e2e.arc-cluster=$(ARC_CLUSTER) \
-				 -e2e.token-exchange-image=$(MSAL_GO_E2E_IMAGE) \
-				 -e2e.proxy-image=$(PROXY_IMAGE) \
-				 -e2e.proxy-init-image=$(INIT_IMAGE)
+				 -e2e.token-exchange-image=$(MSAL_GO_E2E_IMAGE)
 E2E_EXTRA_ARGS ?=
 
 .PHONY: test-e2e-run

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -94,8 +94,7 @@ test_helm_chart() {
     --debug \
     -v=5
   poll_webhook_readiness
-  # TODO(chewong): remove GINKGO_SKIP once the helm chart is updated to use v0.11.0.
-  GINKGO_SKIP="Proxy|should mutate a deployment pod with an annotated service account" make test-e2e-run
+  make test-e2e-run
 
   ${HELM} upgrade --install workload-identity-webhook "${REPO_ROOT}/manifest_staging/charts/workload-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/workload-identity/webhook}" \

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -27,8 +27,6 @@ import (
 var (
 	arcCluster            bool
 	tokenExchangeE2EImage string
-	proxyInitImage        string
-	proxyImage            string
 
 	c              *kubernetes.Clientset
 	coreNamespaces = []string{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -14,8 +14,6 @@ import (
 func init() {
 	flag.BoolVar(&arcCluster, "e2e.arc-cluster", false, "Running on an arc-enabled cluster")
 	flag.StringVar(&tokenExchangeE2EImage, "e2e.token-exchange-image", "aramase/msal-go:v0.6.0", "The image to use for token exchange tests")
-	flag.StringVar(&proxyInitImage, "e2e.proxy-init-image", "mcr.microsoft.com/oss/azure/workload-identity/proxy-init:v0.11.0", "The proxy-init image")
-	flag.StringVar(&proxyImage, "e2e.proxy-image", "mcr.microsoft.com/oss/azure/workload-identity/proxy:v0.11.0", "The proxy image")
 }
 
 // handleFlags sets up all flags and parses the command line.

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -41,7 +41,10 @@ var _ = ginkgo.Describe("Proxy [LinuxOnly] [AKSSoakOnly] [Exclude:Arc]", func() 
 			serviceAccount,
 			"mcr.microsoft.com/azure-cli",
 			nil,
-			[]string{"/bin/sh", "-c", fmt.Sprintf("az login -i -u %s --allow-no-subscriptions --debug; sleep 3600", clientID)},
+			// az login -i reuses the connection, so we need to make sure the token request is made after the proxy sidecar is started
+			// otherwise the token request will fail. The sleep 15 is a workaround for the issue.
+			// TODO(aramase): remove the sleep after https://github.com/Azure/azure-workload-identity/issues/486 is fixed and v0.12.0 is released.
+			[]string{"/bin/sh", "-c", fmt.Sprintf("sleep 15; az login -i -u %s --allow-no-subscriptions --debug; sleep 3600", clientID)},
 			nil,
 			proxyAnnotations,
 			true,


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
