### PR TITLE
chore: add user agent to start log in proxy

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -29,6 +29,10 @@ const (
 	metadataPort = 80
 )
 
+var (
+	userAgent = version.GetUserAgent("proxy")
+)
+
 type Proxy interface {
 	Run() error
 }
@@ -83,13 +87,13 @@ func (p *proxy) Run() error {
 	rtr.PathPrefix(tokenPathPrefix).HandlerFunc(p.msiHandler)
 	rtr.PathPrefix("/").HandlerFunc(p.defaultPathHandler)
 
-	p.logger.Info("starting the proxy server", "port", p.port)
+	p.logger.Info("starting the proxy server", "port", p.port, "userAgent", userAgent)
 	return http.ListenAndServe(fmt.Sprintf("localhost:%d", p.port), rtr)
 }
 
 func (p *proxy) msiHandler(w http.ResponseWriter, r *http.Request) {
 	p.logger.Info("received token request", "method", r.Method, "uri", r.RequestURI)
-	w.Header().Set("Server", version.GetUserAgent("proxy"))
+	w.Header().Set("Server", userAgent)
 	clientID, resource := parseTokenRequest(r)
 	// TODO (aramase) should we fallback to the clientID in the annotated service account
 	// if clientID not found in request? This is to keep consistent with the current behavior


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Logging the user agent at start in proxy to know which version is currently running

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
