### PR TITLE
refactor: migrate golang to MCR and parameterize non-Dockerhub images

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -1,4 +1,6 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} k8s.gcr.io/build-image/debian-iptables:bullseye-v1.5.0
+ARG BASEIMAGE=k8s.gcr.io/build-image/debian-iptables:bullseye-v1.5.0
+
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ${BASEIMAGE}
 
 # upgrading gpgv due to CVE-2022-34903
 RUN clean-install ca-certificates gpgv

--- a/docker/proxy.Dockerfile
+++ b/docker/proxy.Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.18-bullseye as builder
+ARG BUILDER=mcr.microsoft.com/oss/go/microsoft/golang:1.18-bullseye
+ARG BASEIMAGE=gcr.io/distroless/static:nonroot
+
+FROM ${BUILDER} as builder
 
 ARG LDFLAGS
 
@@ -20,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -ld
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM --platform=${TARGETPLATFORM:-linux/amd64} gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ${BASEIMAGE}
 WORKDIR /
 COPY --from=builder /workspace/proxy .
 # Kubernetes runAsNonRoot requires USER to be numeric

--- a/docker/webhook.Dockerfile
+++ b/docker/webhook.Dockerfile
@@ -1,5 +1,8 @@
+ARG BUILDER=mcr.microsoft.com/oss/go/microsoft/golang:1.18-bullseye
+ARG BASEIMAGE=gcr.io/distroless/static:nonroot
+
 # Build the manager binary
-FROM golang:1.18-bullseye as builder
+FROM ${BUILDER} as builder
 
 ARG LDFLAGS
 
@@ -21,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -ld
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM --platform=${TARGETPLATFORM:-linux/amd64} gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ${BASEIMAGE}
 WORKDIR /
 COPY --from=builder /workspace/manager .
 # Kubernetes runAsNonRoot requires USER to be numeric

--- a/examples/msal-go/Dockerfile
+++ b/examples/msal-go/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.18-bullseye as builder
+ARG BUILDER=mcr.microsoft.com/oss/go/microsoft/golang:1.18-bullseye
+ARG BASEIMAGE=gcr.io/distroless/static:nonroot
+
+FROM ${BUILDER} as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -18,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM --platform=${TARGETPLATFORM:-linux/amd64} gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ${BASEIMAGE}
 WORKDIR /
 COPY --from=builder /workspace/msalgo .
 # Kubernetes runAsNonRoot requires USER to be numeric

--- a/examples/msal-java/Dockerfile
+++ b/examples/msal-java/Dockerfile
@@ -1,11 +1,14 @@
-FROM maven:3.8.4-jdk-11 as builder
+ARG BUILDER=maven:3.8.4-jdk-11
+ARG BASEIMAGE=gcr.io/distroless/java:11-nonroot
+
+FROM ${BUILDER} as builder
 WORKDIR /app
 COPY pom.xml .
 RUN mvn -e -B dependency:resolve
 COPY src ./src
 RUN mvn -e -B package
 
-FROM gcr.io/distroless/java:11-nonroot
+FROM ${BASEIMAGE}
 COPY --from=builder /app/target/msal-java-*.jar /app.jar
 # Kubernetes runAsNonRoot requires USER to be numeric
 USER 65532:65532

--- a/examples/msal-node/Dockerfile
+++ b/examples/msal-node/Dockerfile
@@ -1,11 +1,13 @@
-# ref: https://github.com/GoogleContainerTools/distroless/blob/main/examples/nodejs/Dockerfile
+ARG BUILDER=node:14
+ARG BASEIMAGE=gcr.io/distroless/nodejs:16
 
-FROM node:14 AS build-env
+# ref: https://github.com/GoogleContainerTools/distroless/blob/main/examples/nodejs/Dockerfile
+FROM ${BUILDER} AS build-env
 ADD . /app
 WORKDIR /app
 RUN npm install
 
-FROM gcr.io/distroless/nodejs:16
+FROM ${BASEIMAGE}
 COPY --from=build-env /app /app
 WORKDIR /app
 # Kubernetes runAsNonRoot requires USER to be numeric

--- a/examples/msal-python/Dockerfile
+++ b/examples/msal-python/Dockerfile
@@ -14,7 +14,7 @@ COPY requirements.txt /requirements.txt
 RUN /venv/bin/pip install --disable-pip-version-check -r /requirements.txt
 
 # Copy the virtualenv into a distroless image
-FROM gcr.io/distroless/python3-debian11
+FROM ${BASEIMAGE}
 COPY --from=build-venv /venv /venv
 COPY . /app
 WORKDIR /app

--- a/examples/msal-python/Dockerfile
+++ b/examples/msal-python/Dockerfile
@@ -1,6 +1,8 @@
-# ref: https://github.com/GoogleContainerTools/distroless/blob/main/examples/python3-requirements/Dockerfile
+ARG BUILDER=debian:11-slim
+ARG BASEIMAGE=gcr.io/distroless/nodejs:16
 
-FROM debian:11-slim AS build
+# ref: https://github.com/GoogleContainerTools/distroless/blob/main/examples/python3-requirements/Dockerfile
+FROM ${BUILDER}  AS build
 RUN apt-get update && \
     apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
     python3 -m venv /venv && \

--- a/examples/msal-python/Dockerfile
+++ b/examples/msal-python/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILDER=debian:11-slim
-ARG BASEIMAGE=gcr.io/distroless/nodejs:16
+ARG BASEIMAGE=gcr.io/distroless/python3-debian11
 
 # ref: https://github.com/GoogleContainerTools/distroless/blob/main/examples/python3-requirements/Dockerfile
 FROM ${BUILDER}  AS build


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

This PR migrates all Dockerhub images to MCR and parameterizes non-Dockerfile images.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #482. 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
