### PR TITLE
feat: add proxy --probe and enable lifecycle postStart hook

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -33,7 +33,7 @@ func main() {
 	if probe {
 		setupLog := logger.Get().WithName("probe")
 		if err := proxy.Probe(proxyPort); err != nil {
-			setupLog.Error(err, "Failed to probe")
+			setupLog.Error(err, "failed to probe")
 			os.Exit(1)
 		}
 		os.Exit(0)

--- a/pkg/cmd/podidentity/detect.go
+++ b/pkg/cmd/podidentity/detect.go
@@ -370,11 +370,23 @@ func (dc *detectCmd) addProxyContainer(containers []corev1.Container) []corev1.C
 		Name:            proxyContainerName,
 		Image:           proxyImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Args:            []string{"--log-encoder=json"},
+		Args: []string{
+			fmt.Sprintf("--proxy-port=%d", dc.proxyPort),
+		},
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "http",
 				ContainerPort: int32(dc.proxyPort),
+			},
+		},
+		Lifecycle: &corev1.Lifecycle{
+			PostStart: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/proxy",
+						fmt.Sprintf("--proxy-port=%d", dc.proxyPort),
+						"--probe",
+					},
+				},
 			},
 		},
 	}

--- a/pkg/cmd/podidentity/detect_test.go
+++ b/pkg/cmd/podidentity/detect_test.go
@@ -1,6 +1,7 @@
 package podidentity
 
 import (
+	"fmt"
 	"os"
 	"reflect"
 	"strings"
@@ -48,11 +49,23 @@ var (
 		Name:            proxyContainerName,
 		Image:           proxyImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Args:            []string{"--log-encoder=json"},
+		Args: []string{
+			fmt.Sprintf("--proxy-port=%d", 8000),
+		},
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "http",
 				ContainerPort: 8000,
+			},
+		},
+		Lifecycle: &corev1.Lifecycle{
+			PostStart: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/proxy",
+						fmt.Sprintf("--proxy-port=%d", 8000),
+						"--probe",
+					},
+				},
 			},
 		},
 	}

--- a/pkg/proxy/probe.go
+++ b/pkg/proxy/probe.go
@@ -8,6 +8,15 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// retryCount is the number of times to retry probing the proxy.
+	retryCount = 7
+	// waitTime is the time to wait between retries.
+	waitTime = time.Second
+	// clientTimeout is the timeout for the client.
+	clientTimeout = time.Second * 5
+)
+
 // Probe checks if the proxy is ready to serve requests.
 func Probe(port int) error {
 	url := fmt.Sprintf("http://%s:%d%s", localhost, port, readyzPathPrefix)
@@ -16,9 +25,9 @@ func Probe(port int) error {
 
 func probe(url string) error {
 	client := &http.Client{
-		Timeout: time.Second * 5,
+		Timeout: clientTimeout,
 	}
-	for i := 0; i < 7; i++ {
+	for i := 0; i < retryCount; i++ {
 		req, err := http.NewRequest(http.MethodGet, url, nil)
 		if err != nil {
 			return err
@@ -30,7 +39,7 @@ func probe(url string) error {
 		if resp.StatusCode == http.StatusOK {
 			return nil
 		}
-		time.Sleep(time.Second)
+		time.Sleep(waitTime)
 	}
 	return errors.Errorf("failed to probe proxy")
 }

--- a/pkg/proxy/probe.go
+++ b/pkg/proxy/probe.go
@@ -1,0 +1,36 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Probe checks if the proxy is ready to serve requests.
+func Probe(port int) error {
+	url := fmt.Sprintf("http://%s:%d%s", localhost, port, readyzPathPrefix)
+	return probe(url)
+}
+
+func probe(url string) error {
+	client := &http.Client{
+		Timeout: time.Second * 5,
+	}
+	for i := 0; i < 7; i++ {
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode == http.StatusOK {
+			return nil
+		}
+		time.Sleep(time.Second)
+	}
+	return errors.Errorf("failed to probe proxy")
+}

--- a/pkg/proxy/probe_test.go
+++ b/pkg/proxy/probe_test.go
@@ -1,0 +1,28 @@
+package proxy
+
+import (
+	"testing"
+
+	"k8s.io/klog/v2/klogr"
+)
+
+func TestProbe(t *testing.T) {
+	setup()
+	defer teardown()
+
+	p := &proxy{logger: klogr.New()}
+	rtr.PathPrefix("/readyz").HandlerFunc(p.readyzHandler)
+
+	if err := probe(server.URL + "/readyz"); err != nil {
+		t.Errorf("probe() = %v, want nil", err)
+	}
+}
+
+func TestProbeError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	if err := probe(server.URL + "/readyz"); err == nil {
+		t.Errorf("probe() = nil, want error")
+	}
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -254,6 +254,17 @@ func (m *podMutator) injectProxySidecarContainer(containers []corev1.Container, 
 		Ports: []corev1.ContainerPort{{
 			ContainerPort: proxyPort,
 		}},
+		Lifecycle: &corev1.Lifecycle{
+			PostStart: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/proxy",
+						fmt.Sprintf("--proxy-port=%d", proxyPort),
+						"--probe",
+					},
+				},
+			},
+		},
 	})
 
 	return containers

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1256,6 +1256,17 @@ func TestInjectProxySidecarContainer(t *testing.T) {
 		Ports: []corev1.ContainerPort{{
 			ContainerPort: proxyPort,
 		}},
+		Lifecycle: &corev1.Lifecycle{
+			PostStart: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/proxy",
+						fmt.Sprintf("--proxy-port=%d", proxyPort),
+						"--probe",
+					},
+				},
+			},
+		},
 	}
 
 	tests := []struct {

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -94,7 +94,9 @@ test_helm_chart() {
     --debug \
     -v=5
   poll_webhook_readiness
-  make test-e2e-run
+  # TODO(aramase: remove GINKGO_SKIP once helm chart is updated to use v0.12.0 to include the 
+  # new proxy probe feature.
+  GINKGO_SKIP=Proxy make test-e2e-run
 
   ${HELM} upgrade --install workload-identity-webhook "${REPO_ROOT}/manifest_staging/charts/workload-identity-webhook" \
     --set image.repository="${REGISTRY:-mcr.microsoft.com/oss/azure/workload-identity/webhook}" \

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -41,10 +41,7 @@ var _ = ginkgo.Describe("Proxy [LinuxOnly] [AKSSoakOnly] [Exclude:Arc]", func() 
 			serviceAccount,
 			"mcr.microsoft.com/azure-cli",
 			nil,
-			// az login -i reuses the connection, so we need to make sure the token request is made after the proxy sidecar is started
-			// otherwise the token request will fail. The sleep 15 is a workaround for the issue.
-			// TODO(aramase): remove the sleep after https://github.com/Azure/azure-workload-identity/issues/486 is fixed and v0.12.0 is released.
-			[]string{"/bin/sh", "-c", fmt.Sprintf("sleep 15; az login -i -u %s --allow-no-subscriptions --debug; sleep 3600", clientID)},
+			[]string{"/bin/sh", "-c", fmt.Sprintf("az login -i -u %s --allow-no-subscriptions --debug; sleep 3600", clientID)},
 			nil,
 			proxyAnnotations,
 			true,


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Adds a new `--probe` option to the proxy binary
   - When proxy is run with `--probe`, it'll run a readyz probe to check if the proxy is running and ready to serve requests.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #486 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
