### PR TITLE
docs: remove kubernetes version 1.21 (EOL)

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -142,14 +142,12 @@ jobs:
         value: "true"
     strategy:
       matrix:
-        kind_v1_21_10:
-          KIND_NODE_VERSION: v1.21.10
-        kind_v1_22_7:
-          KIND_NODE_VERSION: v1.22.7
-        kind_v1_23_5:
-          KIND_NODE_VERSION: v1.23.5
-        kind_v1_24_1:
-          KIND_NODE_VERSION: v1.24.1
+        kind_v1_22_9:
+          KIND_NODE_VERSION: v1.22.9
+        kind_v1_23_6:
+          KIND_NODE_VERSION: v1.23.6
+        kind_v1_24_2:
+          KIND_NODE_VERSION: v1.24.2
     steps:
       - script: make test-e2e
         displayName: Webhook E2E test suite

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -91,20 +91,16 @@ jobs:
           REGISTRY: upstream.azurecr.io/azure-workload-identity
           ARC_CLUSTER: "true"
           GINKGO_SKIP: \[AKSSoakOnly\]
-        kind_v1_21_10:
-          KIND_NODE_VERSION: v1.21.10
+        kind_v1_22_9:
+          KIND_NODE_VERSION: v1.22.9
           LOCAL_ONLY: "true"
           TEST_HELM_CHART: "true"
-        kind_v1_22_7:
-          KIND_NODE_VERSION: v1.22.7
+        kind_v1_23_6:
+          KIND_NODE_VERSION: v1.23.6
           LOCAL_ONLY: "true"
           TEST_HELM_CHART: "true"
-        kind_v1_23_5:
-          KIND_NODE_VERSION: v1.23.5
-          LOCAL_ONLY: "true"
-          TEST_HELM_CHART: "true"
-        kind_v1_24_1:
-          KIND_NODE_VERSION: v1.24.1
+        kind_v1_24_2:
+          KIND_NODE_VERSION: v1.24.2
           LOCAL_ONLY: "true"
           TEST_HELM_CHART: "true"
     steps:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Azure AD Workload Identity is the next iteration of [Azure AD Pod Identity][1] t
 | 1.24               | ✅         |
 | 1.23               | ✅         |
 | 1.22               | ✅         |
-| 1.21               | ✅         |
 
 ## Installation
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Remove Kubernetes version 1.21 from docs and CI since it has reached EOL
- Update Kubernetes versions to latest in CI for supported releases

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
