### PR TITLE
ci: update `SERVICE_ACCOUNT_ISSUER` in azwi e2e

### DIFF
--- a/.github/workflows/azwi-e2e.yaml
+++ b/.github/workflows/azwi-e2e.yaml
@@ -18,7 +18,7 @@ jobs:
     env:
       AZURE_CLIENT_ID: 0dcfc182-7b36-4e23-b53f-a27c929a9e4e
       AZURE_TENANT_ID: bc2d60ab-9b1d-45bd-8a3b-3a18ae865e3a
-      SERVICE_ACCOUNT_ISSUER: "https://chuwon.blob.core.windows.net/oidc-test/"
+      SERVICE_ACCOUNT_ISSUER: "https://azwi.blob.core.windows.net/oidc-test/"
     strategy:
       fail-fast: false
       matrix:

--- a/docs/book/src/topics/azwi/serviceaccount-create.md
+++ b/docs/book/src/topics/azwi/serviceaccount-create.md
@@ -44,7 +44,7 @@ The "create" command executes the following phases in order:
 az login && az account set -s <SubscriptionID>
 azwi serviceaccount create \
   --service-account-name azwi-sa \
-  --service-account-issuer-url https://chuwon.blob.core.windows.net/oidc-test/ \
+  --service-account-issuer-url https://azwi.blob.core.windows.net/oidc-test/ \
   --skip-phases role-assignment
 ```
 

--- a/docs/book/src/topics/azwi/serviceaccount-delete.md
+++ b/docs/book/src/topics/azwi/serviceaccount-delete.md
@@ -39,7 +39,7 @@ The "delete" command executes the following phases in order:
 az login && az account set -s <SubscriptionID>
 azwi sa delete \
   --service-account-name azwi-sa \
-  --service-account-issuer-url https://chuwon.blob.core.windows.net/oidc-test/ \
+  --service-account-issuer-url https://azwi.blob.core.windows.net/oidc-test/ \
   --skip-phases role-assignment
 ```
 
@@ -48,7 +48,7 @@ azwi sa delete \
 
     INFO[0000] No subscription provided, using selected subscription from Azure CLI: <SubscriptionID>
     INFO[0001] skipping phase                                phase=role-assignment
-    INFO[0001] [federated-identity] deleted federated identity credential  issuerURL="https://chuwon.blob.core.windows.net/oidc-test/" subject="system:serviceaccount:default:azwi-sa"
+    INFO[0001] [federated-identity] deleted federated identity credential  issuerURL="https://azwi.blob.core.windows.net/oidc-test/" subject="system:serviceaccount:default:azwi-sa"
     INFO[0001] [service-account] deleted service account     name=azwi-sa namespace=default
     INFO[0001] [aad-application] deleted aad application     objectID=19888f97-e0d3-4f61-8eb9-b87bf161e27d
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Updates the `SERVICE_ACCOUNT_ISSUER` for azwi e2e
  - https://azwi.blob.core.windows.net/oidc-test/.well-known/openid-configuration

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
