### PR TITLE
refactor: Improve Reactor API usage in Java example

### DIFF
--- a/examples/msal-java/pom.xml
+++ b/examples/msal-java/pom.xml
@@ -13,8 +13,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -37,6 +37,12 @@
       <groupId>com.microsoft.azure</groupId>
       <artifactId>msal4j</artifactId>
       <version>1.11.2</version>
+    </dependency>
+    <!-- in a real application, you would use a proper logging implementation such as log4j2 or logback -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.32</version>
     </dependency>
   </dependencies>
   <build>

--- a/examples/msal-java/src/main/java/com/example/msal/java/CustomTokenCredential.java
+++ b/examples/msal-java/src/main/java/com/example/msal/java/CustomTokenCredential.java
@@ -15,41 +15,37 @@ import com.azure.core.credential.TokenRequestContext;
 import com.microsoft.aad.msal4j.ClientCredentialFactory;
 import com.microsoft.aad.msal4j.ClientCredentialParameters;
 import com.microsoft.aad.msal4j.ConfidentialClientApplication;
-import com.microsoft.aad.msal4j.IAuthenticationResult;
 import com.microsoft.aad.msal4j.IClientCredential;
 
 import reactor.core.publisher.Mono;
 
 public class CustomTokenCredential implements TokenCredential {
-    public Mono<AccessToken> getToken(TokenRequestContext request) {
+    private final ConfidentialClientApplication app;
+    
+    public CustomTokenCredential() {
         Map<String, String> env = System.getenv();
         String clientAssertion;
         try {
             clientAssertion = new String(Files.readAllBytes(Paths.get(env.get("AZURE_FEDERATED_TOKEN_FILE"))),
                     StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
 
-        IClientCredential credential = ClientCredentialFactory.createFromClientAssertion(clientAssertion);
-        String authority = env.get("AZURE_AUTHORITY_HOST") + env.get("AZURE_TENANT_ID");
-        try {
-            ConfidentialClientApplication app = ConfidentialClientApplication
-                    .builder(env.get("AZURE_CLIENT_ID"), credential).authority(authority).build();
-
-            Set<String> scopes = new HashSet<>();
-            for (String scope : request.getScopes())
-                scopes.add(scope);
-
-            ClientCredentialParameters parameters = ClientCredentialParameters.builder(scopes).build();
-            IAuthenticationResult result = app.acquireToken(parameters).join();
-            return Mono.just(
-                    new AccessToken(result.accessToken(), result.expiresOnDate().toInstant().atOffset(ZoneOffset.UTC)));
+            IClientCredential credential = ClientCredentialFactory.createFromClientAssertion(clientAssertion);
+            String authority = env.get("AZURE_AUTHORITY_HOST") + env.get("AZURE_TENANT_ID");
+            app = ConfidentialClientApplication.builder(env.get("AZURE_CLIENT_ID"), credential)
+                    .authority(authority).build();
         } catch (Exception e) {
             System.out.printf("Error creating client application: %s", e.getMessage());
-            System.exit(1);
+            throw new RuntimeException(e);
         }
+    }
+    
+    public Mono<AccessToken> getToken(TokenRequestContext request) {
+        Set<String> scopes = new HashSet<>();
+        for (String scope : request.getScopes())
+            scopes.add(scope);
 
-        return Mono.empty();
+        ClientCredentialParameters parameters = ClientCredentialParameters.builder(scopes).build();
+        return Mono.defer(() -> Mono.fromFuture(app.acquireToken(parameters))).map((result) ->
+                new AccessToken(result.accessToken(), result.expiresOnDate().toInstant().atOffset(ZoneOffset.UTC)));
     }
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

The current msal-java example exhibits very poor practice in the use of reactive streams.  When a method like `TokenCredential.getToken` returns a `Mono` the caller should expect that the calling thread will not block, and that any potentially long running operations will occur when the resulting `Mono` is _subscribed_, rather than blocking the caller.  Currently `getToken` includes two blocking operations, first the read of the token file from disk and second the call to `CompletableFuture.join()` on the future returned by `ConfidentialClientApplication.acquireToken`.

This PR moves the file read into the `CustomTokenCredential` constructor (which is not a reactive call), and makes `getToken` properly non-blocking.

**Requirements**

- [x] squashed commits
- [ ] included documentation (n/a)
- [ ] added unit tests and e2e tests (if applicable). (n/a)

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project?

- [ ] yes
- [x] no

**Notes for Reviewers**:
