### PR TITLE
ci: remove `upgrade_aks_linux` tests in pr.yaml

### DIFF
--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -120,13 +120,3 @@ jobs:
         displayName: Cleanup
         condition: ne(variables.LOCAL_ONLY, 'true')
       - template: templates/publish-logs.yaml
-  - template: templates/upgrade.yaml
-    parameters:
-      dependsOn:
-        - lint
-        - scan_images
-        - shellcheck
-        - unit_test
-      matrix:
-        upgrade_aks_linux:
-          GINKGO_SKIP: \[AKSSoakOnly\]


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
The AKS upgrade tests take 34m to complete. Upgrade tests are run as part of nightly CI, so removing it from PR gate to improve merge time.

https://github.com/Azure/azure-workload-identity/blob/8644a217f09902fa1ac63e05cf04d9a3f3f1ebc3/.pipelines/nightly.yaml#L105-L122

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
