### PR TITLE
Add namespace selector to mutatingwebhook configuration

### DIFF
--- a/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -20,6 +20,10 @@ webhooks:
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: mutation.azure-workload-identity.io
+  {{- if .Values.namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml .Values.namespaceSelector | nindent 4 }}
+  {{- end }}
   rules:
   - apiGroups:
     - ""

--- a/charts/workload-identity-webhook/values.yaml
+++ b/charts/workload-identity-webhook/values.yaml
@@ -31,3 +31,9 @@ azureTenantID:
 logEncoder: console
 metricsAddr: ":8095"
 metricsBackend: prometheus
+namespaceSelector:
+  matchExpressions:
+    - key: project
+      operator: NotIn
+      values:
+        - name_space


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
Adds the ability to provide a filter for the mutatingwebhookconfiguration. 
Currently azure admission pods rely on this webhook as well. if for some reason these pods are restarted they cant be validated, since they need the webhook pods, hence the cluster will hang. 

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
