### PR TITLE
security: fix multiple CVEs

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -4,7 +4,9 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} ${BASEIMAGE}
 
 # upgrading gpgv due to CVE-2022-34903
 # upgrading libgnutls30 due to CVE-2021-4209
-RUN clean-install ca-certificates gpgv libgnutls30
+# upgrading libtirpc-common due to CVE-2021-46828
+# upgrading libtirpc3 due to CVE-2021-46828
+RUN clean-install ca-certificates gpgv libgnutls30 libtirpc-common libtirpc3
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh
 # Kubernetes runAsNonRoot requires USER to be numeric


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
```shell
e2e/proxy-init:test-linux-amd64 (debian 11.3)
=============================================
Total: 2 (MEDIUM: 0, HIGH: 2, CRITICAL: 0)

+-----------------+------------------+----------+-------------------+-----------------+---------------------------------------+
|     LIBRARY     | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION  |                 TITLE                 |
+-----------------+------------------+----------+-------------------+-----------------+---------------------------------------+
| libtirpc-common | CVE-2021-46828   | HIGH     | 1.3.1-1           | 1.3.1-1+deb11u1 | libtirpc: DoS vulnerability           |
|                 |                  |          |                   |                 | with lots of connections              |
|                 |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2021-46828 |
+-----------------+                  +          +                   +                 +                                       +
| libtirpc3       |                  |          |                   |                 |                                       |
|                 |                  |          |                   |                 |                                       |
|                 |                  |          |                   |                 |                                       |
+-----------------+------------------+----------+-------------------+-----------------+---------------------------------------+
```

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
