### PR TITLE
Add objectselector to mutating webhook

### DIFF
--- a/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: '{{ template "workload-identity-webhook.name" . }}'
     release: '{{ .Release.Name }}'
   name: azure-wi-webhook-mutating-webhook-configuration
+  {{- if .Values.objectSelector }}
+  objectSelector:
+  {{- toYaml .Values.objectSelector | nindent 4 }}
+  {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -8,10 +8,6 @@ metadata:
     chart: '{{ template "workload-identity-webhook.name" . }}'
     release: '{{ .Release.Name }}'
   name: azure-wi-webhook-mutating-webhook-configuration
-  {{- if .Values.objectSelector }}
-  objectSelector:
-  {{- toYaml .Values.objectSelector | nindent 4 }}
-  {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -24,6 +20,10 @@ webhooks:
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: mutation.azure-workload-identity.io
+  {{- if .Values.objectSelector }}
+  objectSelector:
+  {{- toYaml .Values.objectSelector | nindent 4 }}
+  {{- end }}
   rules:
   - apiGroups:
     - ""

--- a/charts/workload-identity-webhook/values.yaml
+++ b/charts/workload-identity-webhook/values.yaml
@@ -31,3 +31,7 @@ azureTenantID:
 logEncoder: console
 metricsAddr: ":8095"
 metricsBackend: prometheus
+objectSelector:
+  matchLabels:
+    foo: 'bar'
+

--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -20,6 +20,10 @@ webhooks:
   failurePolicy: Ignore
   matchPolicy: Equivalent
   name: mutation.azure-workload-identity.io
+  {{- if .Values.objectSelector }}
+  objectSelector:
+  {{- toYaml .Values.objectSelector | nindent 4 }}
+  {{- end }}
   rules:
   - apiGroups:
     - ""


### PR DESCRIPTION
adds the option to use the objectselector to only use this webhook when pods match a certain label.

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
Currently, all pods rely on this webhook to be working properly in order to start-up. Even the webhook pods itself. if in any case the webhook pods are terminated, they won't be able to spin up again, since they rely on the pods itself.
Adding this object selector can prevent such a situation.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
