### PR TITLE
feat: make priority class name configurable in helm charts

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,3 +74,4 @@ spec:
               name: azure-wi-webhook-config
       nodeSelector:
         kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical

--- a/manifest_staging/charts/workload-identity-webhook/README.md
+++ b/manifest_staging/charts/workload-identity-webhook/README.md
@@ -50,6 +50,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | metricsAddr                  | The address to bind the metrics server to                                | `:8095`                                                 |
 | metricsBackend               | The metrics backend to use (`prometheus`)                                | `prometheus`                                            |
 | mutatingWebhookFailurePolicy | The failurePolicy for the mutating webhook                               | `Ignore`                                                |
+| priorityClassName            | The priority class name for webhook manager                              | `system-cluster-critical`                               |
 
 ## Contributing Changes
 

--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-controller-manager-deployment.yaml
@@ -83,6 +83,7 @@ spec:
           readOnly: true
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
+      priorityClassName: {{ .Values.priorityClassName }}
       serviceAccountName: azure-wi-webhook-admin
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}

--- a/manifest_staging/charts/workload-identity-webhook/values.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/values.yaml
@@ -32,3 +32,4 @@ logEncoder: console
 metricsAddr: ":8095"
 metricsBackend: prometheus
 mutatingWebhookFailurePolicy: Ignore
+priorityClassName: system-cluster-critical

--- a/manifest_staging/deploy/azure-wi-webhook.yaml
+++ b/manifest_staging/deploy/azure-wi-webhook.yaml
@@ -213,6 +213,7 @@ spec:
           readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
       serviceAccountName: azure-wi-webhook-admin
       volumes:
       - name: cert

--- a/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
@@ -71,6 +71,7 @@ spec:
         secret:
           defaultMode: 420
           secretName: azure-wi-webhook-server-cert
+      priorityClassName: HELMSUBST_DEPLOYMENT_PRIORITY_CLASS_NAME
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
+++ b/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
@@ -22,4 +22,6 @@ var replacements = map[string]string{
 	"HELMSUBST_DEPLOYMENT_METRICS_PORT": `{{ trimPrefix ":" .Values.metricsAddr }}`,
 
 	"HELMSUBST_MUTATING_WEBHOOK_FAILURE_POLICY": `{{ .Values.mutatingWebhookFailurePolicy }}`,
+
+	"HELMSUBST_DEPLOYMENT_PRIORITY_CLASS_NAME": `{{ .Values.priorityClassName }}`,
 }

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
@@ -50,6 +50,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | metricsAddr                  | The address to bind the metrics server to                                | `:8095`                                                 |
 | metricsBackend               | The metrics backend to use (`prometheus`)                                | `prometheus`                                            |
 | mutatingWebhookFailurePolicy | The failurePolicy for the mutating webhook                               | `Ignore`                                                |
+| priorityClassName            | The priority class name for webhook manager                              | `system-cluster-critical`                               |
 
 ## Contributing Changes
 

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
@@ -32,3 +32,4 @@ logEncoder: console
 metricsAddr: ":8095"
 metricsBackend: prometheus
 mutatingWebhookFailurePolicy: Ignore
+priorityClassName: system-cluster-critical


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Make priority class name configurable in helm chart
- Set default priority class name to `system-cluster-critical` for the webhook

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/519

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
