### PR TITLE
feat: make mwh failurePolicy configurable in helm charts

### DIFF
--- a/manifest_staging/charts/workload-identity-webhook/README.md
+++ b/manifest_staging/charts/workload-identity-webhook/README.md
@@ -29,26 +29,27 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 
 ## Parameters
 
-| Parameter          | Description                                                              | Default                                                 |
-| :----------------- | :----------------------------------------------------------------------- | :------------------------------------------------------ |
-| labels             | The labels to add to the azure-workload-identity webhook pods            | `azure-workload-identity.io/system: "true"`             |
-| replicaCount       | The number of azure-workload-identity replicas to deploy for the webhook | `2`                                                     |
-| image.repository   | Image repository                                                         | `mcr.microsoft.com/oss/azure/workload-identity/webhook` |
-| image.pullPolicy   | Image pullPolicy                                                         | `IfNotPresent`                                          |
-| image.release      | The image release tag to use                                             | Current release version: `v0.12.0`                      |
-| nodeSelector       | The node selector to use for pod scheduling                              | `kubernetes.io/os: linux`                               |
-| arcCluster         | Specify if it runs on Arc cluster                                        | `false`                                                 |
-| resources          | The resource request/limits for the container image                      | limits: 100m CPU, 30Mi, requests: 100m CPU, 20Mi        |
-| affinity           | The node affinity to use for pod scheduling                              | `{}`                                                    |
-| tolerations        | The tolerations to use for pod scheduling                                | `[]`                                                    |
-| service.type       | Service type                                                             | `ClusterIP`                                             |
-| service.port       | Service port                                                             | `443`                                                   |
-| service.targetPort | Service target port                                                      | `9443`                                                  |
-| azureTenantID      | [**REQUIRED**] Azure tenant ID                                           | ``                                                      |
-| azureEnvironment   | Azure Environment                                                        | `AzurePublicCloud`                                      |
-| logEncoder         | The log encoder to use for the webhook manager (`json`, `console`)       | `console`                                               |
-| metricsAddr        | The address to bind the metrics server to                                | `:8095`                                                 |
-| metricsBackend     | The metrics backend to use (`prometheus`)                                | `prometheus`                                            |
+| Parameter                    | Description                                                              | Default                                                 |
+| :--------------------------- | :----------------------------------------------------------------------- | :------------------------------------------------------ |
+| labels                       | The labels to add to the azure-workload-identity webhook pods            | `azure-workload-identity.io/system: "true"`             |
+| replicaCount                 | The number of azure-workload-identity replicas to deploy for the webhook | `2`                                                     |
+| image.repository             | Image repository                                                         | `mcr.microsoft.com/oss/azure/workload-identity/webhook` |
+| image.pullPolicy             | Image pullPolicy                                                         | `IfNotPresent`                                          |
+| image.release                | The image release tag to use                                             | Current release version: `v0.12.0`                      |
+| nodeSelector                 | The node selector to use for pod scheduling                              | `kubernetes.io/os: linux`                               |
+| arcCluster                   | Specify if it runs on Arc cluster                                        | `false`                                                 |
+| resources                    | The resource request/limits for the container image                      | limits: 100m CPU, 30Mi, requests: 100m CPU, 20Mi        |
+| affinity                     | The node affinity to use for pod scheduling                              | `{}`                                                    |
+| tolerations                  | The tolerations to use for pod scheduling                                | `[]`                                                    |
+| service.type                 | Service type                                                             | `ClusterIP`                                             |
+| service.port                 | Service port                                                             | `443`                                                   |
+| service.targetPort           | Service target port                                                      | `9443`                                                  |
+| azureTenantID                | [**REQUIRED**] Azure tenant ID                                           | ``                                                      |
+| azureEnvironment             | Azure Environment                                                        | `AzurePublicCloud`                                      |
+| logEncoder                   | The log encoder to use for the webhook manager (`json`, `console`)       | `console`                                               |
+| metricsAddr                  | The address to bind the metrics server to                                | `:8095`                                                 |
+| metricsBackend               | The metrics backend to use (`prometheus`)                                | `prometheus`                                            |
+| mutatingWebhookFailurePolicy | The failurePolicy for the mutating webhook                               | `Ignore`                                                |
 
 ## Contributing Changes
 

--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -1,7 +1,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   labels:
     app: '{{ template "workload-identity-webhook.name" . }}'
     azure-workload-identity.io/system: "true"
@@ -17,7 +16,7 @@ webhooks:
       name: azure-wi-webhook-webhook-service
       namespace: '{{ .Release.Namespace }}'
       path: /mutate-v1-pod
-  failurePolicy: Ignore
+  failurePolicy: {{ .Values.mutatingWebhookFailurePolicy }}
   matchPolicy: Equivalent
   name: mutation.azure-workload-identity.io
   rules:

--- a/manifest_staging/charts/workload-identity-webhook/values.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/values.yaml
@@ -31,3 +31,4 @@ azureTenantID:
 logEncoder: console
 metricsAddr: ":8095"
 metricsBackend: prometheus
+mutatingWebhookFailurePolicy: Ignore

--- a/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
@@ -71,3 +71,16 @@ spec:
         secret:
           defaultMode: 420
           secretName: azure-wi-webhook-server-cert
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1-pod
+  failurePolicy: HELMSUBST_MUTATING_WEBHOOK_FAILURE_POLICY
+  name: mutation.azure-workload-identity.io

--- a/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
+++ b/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
@@ -20,4 +20,6 @@ var replacements = map[string]string{
   {{- end }}`,
 
 	"HELMSUBST_DEPLOYMENT_METRICS_PORT": `{{ trimPrefix ":" .Values.metricsAddr }}`,
+
+	"HELMSUBST_MUTATING_WEBHOOK_FAILURE_POLICY": `{{ .Values.mutatingWebhookFailurePolicy }}`,
 }

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
@@ -29,26 +29,27 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 
 ## Parameters
 
-| Parameter          | Description                                                              | Default                                                 |
-| :----------------- | :----------------------------------------------------------------------- | :------------------------------------------------------ |
-| labels             | The labels to add to the azure-workload-identity webhook pods            | `azure-workload-identity.io/system: "true"`             |
-| replicaCount       | The number of azure-workload-identity replicas to deploy for the webhook | `2`                                                     |
-| image.repository   | Image repository                                                         | `mcr.microsoft.com/oss/azure/workload-identity/webhook` |
-| image.pullPolicy   | Image pullPolicy                                                         | `IfNotPresent`                                          |
-| image.release      | The image release tag to use                                             | Current release version: `v0.12.0`                      |
-| nodeSelector       | The node selector to use for pod scheduling                              | `kubernetes.io/os: linux`                               |
-| arcCluster         | Specify if it runs on Arc cluster                                        | `false`                                                 |
-| resources          | The resource request/limits for the container image                      | limits: 100m CPU, 30Mi, requests: 100m CPU, 20Mi        |
-| affinity           | The node affinity to use for pod scheduling                              | `{}`                                                    |
-| tolerations        | The tolerations to use for pod scheduling                                | `[]`                                                    |
-| service.type       | Service type                                                             | `ClusterIP`                                             |
-| service.port       | Service port                                                             | `443`                                                   |
-| service.targetPort | Service target port                                                      | `9443`                                                  |
-| azureTenantID      | [**REQUIRED**] Azure tenant ID                                           | ``                                                      |
-| azureEnvironment   | Azure Environment                                                        | `AzurePublicCloud`                                      |
-| logEncoder         | The log encoder to use for the webhook manager (`json`, `console`)       | `console`                                               |
-| metricsAddr        | The address to bind the metrics server to                                | `:8095`                                                 |
-| metricsBackend     | The metrics backend to use (`prometheus`)                                | `prometheus`                                            |
+| Parameter                    | Description                                                              | Default                                                 |
+| :--------------------------- | :----------------------------------------------------------------------- | :------------------------------------------------------ |
+| labels                       | The labels to add to the azure-workload-identity webhook pods            | `azure-workload-identity.io/system: "true"`             |
+| replicaCount                 | The number of azure-workload-identity replicas to deploy for the webhook | `2`                                                     |
+| image.repository             | Image repository                                                         | `mcr.microsoft.com/oss/azure/workload-identity/webhook` |
+| image.pullPolicy             | Image pullPolicy                                                         | `IfNotPresent`                                          |
+| image.release                | The image release tag to use                                             | Current release version: `v0.12.0`                      |
+| nodeSelector                 | The node selector to use for pod scheduling                              | `kubernetes.io/os: linux`                               |
+| arcCluster                   | Specify if it runs on Arc cluster                                        | `false`                                                 |
+| resources                    | The resource request/limits for the container image                      | limits: 100m CPU, 30Mi, requests: 100m CPU, 20Mi        |
+| affinity                     | The node affinity to use for pod scheduling                              | `{}`                                                    |
+| tolerations                  | The tolerations to use for pod scheduling                                | `[]`                                                    |
+| service.type                 | Service type                                                             | `ClusterIP`                                             |
+| service.port                 | Service port                                                             | `443`                                                   |
+| service.targetPort           | Service target port                                                      | `9443`                                                  |
+| azureTenantID                | [**REQUIRED**] Azure tenant ID                                           | ``                                                      |
+| azureEnvironment             | Azure Environment                                                        | `AzurePublicCloud`                                      |
+| logEncoder                   | The log encoder to use for the webhook manager (`json`, `console`)       | `console`                                               |
+| metricsAddr                  | The address to bind the metrics server to                                | `:8095`                                                 |
+| metricsBackend               | The metrics backend to use (`prometheus`)                                | `prometheus`                                            |
+| mutatingWebhookFailurePolicy | The failurePolicy for the mutating webhook                               | `Ignore`                                                |
 
 ## Contributing Changes
 

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
@@ -31,3 +31,4 @@ azureTenantID:
 logEncoder: console
 metricsAddr: ":8095"
 metricsBackend: prometheus
+mutatingWebhookFailurePolicy: Ignore


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Make mwh `failurePolicy` configurable in helm charts

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/516

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
