### PR TITLE
docs: add AKS admission enforcer to known issues

### DIFF
--- a/docs/book/src/known-issues.md
+++ b/docs/book/src/known-issues.md
@@ -57,3 +57,16 @@ URI="https://graph.microsoft.com/v1.0/servicePrincipals/${APPLICATION_OBJECT_ID}
 BODY="{'principalId':'${APPLICATION_OBJECT_ID}','resourceId':'${GRAPH_RESOURCE_ID}','appRoleId':'${APPLICATION_READWRITE_ALL_ID}'}"
 az rest --method post --uri "${URI}" --body "${BODY}" --headers "Content-Type=application/json"
 ```
+
+### Container environment variables not injected into pods deployed to the kube-system namesapce on an AKS cluster
+
+This isssue was observed on an aks cluster version 1.22. This is due to the [admission control](https://docs.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-impact-kube-system-and-internal-aks-namespaces) on the kube-system namespace.
+
+To overcome this issue an annotation
+
+```
+annotations: 
+    admissions.enforcer/disabled: "true"
+```
+
+ must be added to the azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml

--- a/docs/book/src/known-issues.md
+++ b/docs/book/src/known-issues.md
@@ -60,13 +60,6 @@ az rest --method post --uri "${URI}" --body "${BODY}" --headers "Content-Type=ap
 
 ### Environment variables not injected into pods deployed in the kube-system namespace in an AKS cluster
 
-This isssue was observed on an aks cluster version 1.22. This is due to the [admission control](https://docs.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-impact-kube-system-and-internal-aks-namespaces) on the kube-system namespace.
+To protect the stability of the system and prevent custom admission controllers from impacting internal services in the kube-system, namespace AKS has an Admissions Enforcer, which automatically excludes kube-system and AKS internal namespaces. Refer to [doc](https://docs.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-impact-kube-system-and-internal-aks-namespaces) for more details.
 
-To overcome this issue an annotation
-
-```
-annotations: 
-    admissions.enforcer/disabled: "true"
-```
-
- must be added to the azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+If you're deploying a pod in the `kube-system` namespace of an AKS cluster and need the environment variables, projected service account token volume injected by the Azure Workload Identity Mutating Webhook, add the `"admissions.enforcer/disabled": "true"` label or annotation in the [MutatingWebhookConfiguration](https://github.com/Azure/azure-workload-identity/blob/8644a217f09902fa1ac63e05cf04d9a3f3f1ebc3/deploy/azure-wi-webhook.yaml#L206-L235).

--- a/docs/book/src/known-issues.md
+++ b/docs/book/src/known-issues.md
@@ -58,7 +58,7 @@ BODY="{'principalId':'${APPLICATION_OBJECT_ID}','resourceId':'${GRAPH_RESOURCE_I
 az rest --method post --uri "${URI}" --body "${BODY}" --headers "Content-Type=application/json"
 ```
 
-### Container environment variables not injected into pods deployed to the kube-system namesapce on an AKS cluster
+### Environment variables not injected into pods deployed in the kube-system namespace in an AKS cluster
 
 This isssue was observed on an aks cluster version 1.22. This is due to the [admission control](https://docs.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-impact-kube-system-and-internal-aks-namespaces) on the kube-system namespace.
 


### PR DESCRIPTION
Added known issue as discussed here: https://github.com/Azure/azure-workload-identity/issues/525

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
