### PR TITLE
feat: allow setting mwh annotations in helm charts

### DIFF
--- a/manifest_staging/charts/workload-identity-webhook/README.md
+++ b/manifest_staging/charts/workload-identity-webhook/README.md
@@ -51,6 +51,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | metricsBackend               | The metrics backend to use (`prometheus`)                                | `prometheus`                                            |
 | mutatingWebhookFailurePolicy | The failurePolicy for the mutating webhook                               | `Ignore`                                                |
 | priorityClassName            | The priority class name for webhook manager                              | `system-cluster-critical`                               |
+| mutatingWebhookAnnotations   | The annotations to add to the MutatingWebhookConfiguration               | `{}`                                                    |
 
 ## Contributing Changes
 

--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -1,6 +1,8 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  annotations:
+    {{- toYaml .Values.mutatingWebhookAnnotations | nindent 4 }}
   labels:
     app: '{{ template "workload-identity-webhook.name" . }}'
     azure-workload-identity.io/system: "true"

--- a/manifest_staging/charts/workload-identity-webhook/values.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/values.yaml
@@ -33,3 +33,4 @@ metricsAddr: ":8095"
 metricsBackend: prometheus
 mutatingWebhookFailurePolicy: Ignore
 priorityClassName: system-cluster-critical
+mutatingWebhookAnnotations: {}

--- a/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
@@ -77,6 +77,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
+  annotations:
+    HELMSUBST_MUTATING_WEBHOOK_ANNOTATIONS: ""
 webhooks:
 - clientConfig:
     service:

--- a/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
+++ b/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
@@ -24,4 +24,6 @@ var replacements = map[string]string{
 	"HELMSUBST_MUTATING_WEBHOOK_FAILURE_POLICY": `{{ .Values.mutatingWebhookFailurePolicy }}`,
 
 	"HELMSUBST_DEPLOYMENT_PRIORITY_CLASS_NAME": `{{ .Values.priorityClassName }}`,
+
+	`HELMSUBST_MUTATING_WEBHOOK_ANNOTATIONS: ""`: `{{- toYaml .Values.mutatingWebhookAnnotations | nindent 4 }}`,
 }

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
@@ -51,6 +51,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | metricsBackend               | The metrics backend to use (`prometheus`)                                | `prometheus`                                            |
 | mutatingWebhookFailurePolicy | The failurePolicy for the mutating webhook                               | `Ignore`                                                |
 | priorityClassName            | The priority class name for webhook manager                              | `system-cluster-critical`                               |
+| mutatingWebhookAnnotations   | The annotations to add to the MutatingWebhookConfiguration               | `{}`                                                    |
 
 ## Contributing Changes
 

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
@@ -33,3 +33,4 @@ metricsAddr: ":8095"
 metricsBackend: prometheus
 mutatingWebhookFailurePolicy: Ignore
 priorityClassName: system-cluster-critical
+mutatingWebhookAnnotations: {}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
ref: https://azure.github.io/azure-workload-identity/docs/known-issues.html#environment-variables-not-injected-into-pods-deployed-in-the-kube-system-namespace-in-an-aks-cluster

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
resolves #525 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
