### PR TITLE
feat: add pod disruption budget for webhook

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,6 +24,7 @@ bases:
 # - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+- ../pdb
 
 patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.

--- a/config/pdb/kustomization.yaml
+++ b/config/pdb/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- pdb.yaml

--- a/config/pdb/pdb.yaml
+++ b/config/pdb/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: controller-manager
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      azure-workload-identity.io/system: "true"

--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-controller-manager-poddisruptionbudget.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-controller-manager-poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: '{{ template "workload-identity-webhook.name" . }}'
+    azure-workload-identity.io/system: "true"
+    chart: '{{ template "workload-identity-webhook.name" . }}'
+    release: '{{ .Release.Name }}'
+  name: azure-wi-webhook-controller-manager
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: '{{ template "workload-identity-webhook.name" . }}'
+      azure-workload-identity.io/system: "true"
+      chart: '{{ template "workload-identity-webhook.name" . }}'
+      release: '{{ .Release.Name }}'

--- a/manifest_staging/deploy/azure-wi-webhook.yaml
+++ b/manifest_staging/deploy/azure-wi-webhook.yaml
@@ -221,6 +221,19 @@ spec:
           defaultMode: 420
           secretName: azure-wi-webhook-server-cert
 ---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    azure-workload-identity.io/system: "true"
+  name: azure-wi-webhook-controller-manager
+  namespace: azure-workload-identity-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      azure-workload-identity.io/system: "true"
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Add pod disruption budget for webhook

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
