### PR TITLE
security: fix multiple CVEs

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -2,10 +2,9 @@ ARG BASEIMAGE=k8s.gcr.io/build-image/debian-iptables:bullseye-v1.5.1
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ${BASEIMAGE}
 
-# upgrading zlib1g due to CVE-2022-37434
-# upgrading libc-bin and libc6 due to CVE-2021-3999
-# upgrading libpcre2-8-0 due to CVE-2022-1586, CVE-2022-1587
-RUN clean-install ca-certificates zlib1g libc-bin libc6 libpcre2-8-0
+RUN apt update && \
+    apt upgrade -y && \
+    clean-install ca-certificates
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh
 # Kubernetes runAsNonRoot requires USER to be numeric

--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -3,7 +3,9 @@ ARG BASEIMAGE=k8s.gcr.io/build-image/debian-iptables:bullseye-v1.5.1
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ${BASEIMAGE}
 
 # upgrading zlib1g due to CVE-2022-37434
-RUN clean-install ca-certificates zlib1g
+# upgrading libc-bin and libc6 due to CVE-2021-3999
+# upgrading libpcre2-8-0 due to CVE-2022-1586, CVE-2022-1587
+RUN clean-install ca-certificates zlib1g libc-bin libc6 libpcre2-8-0
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh
 # Kubernetes runAsNonRoot requires USER to be numeric


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- fixes https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/results?buildId=56209&view=logs&jobId=50e5c204-a982-5a63-4824-cf22f1b24a4e&j=50e5c204-a982-5a63-4824-cf22f1b24a4e&t=94cd4644-8683-57bb-f7f8-715cbe70e34e
- Run `apt update && apt upgrade -y` to patch CVEs instead of managing individual packages.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
