### PR TITLE
docs: Use KEYVAULT_URL in quick start guide

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -238,6 +238,8 @@ spec:
     - image: ghcr.io/azure/azure-workload-identity/msal-go
       name: oidc
       env:
+      - name: KEYVAULT_NAME
+        value: ${KEYVAULT_NAME}
       - name: KEYVAULT_URL
         value: ${KEYVAULT_URL}
       - name: SECRET_NAME
@@ -246,6 +248,7 @@ spec:
     kubernetes.io/os: linux
 EOF
 ```
+Note: Newer version of the sample image will only need KEYVAULT_URL variable.
 
 > Feel free to swap the msal-go example image above with a list of [language-specific examples](./topics/language-specific-examples/msal.md) we provide.
 

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -225,6 +225,7 @@ az ad app federated-credential create --id ${APPLICATION_OBJECT_ID} --parameters
 Deploy a pod that references the service account created in the last step:
 
 ```bash
+export KEYVAULT_URL="$(az keyvault show -g ${RESOURCE_GROUP} -n ${KEYVAULT_NAME} --query properties.vaultUri -o tsv)"
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
@@ -237,8 +238,8 @@ spec:
     - image: ghcr.io/azure/azure-workload-identity/msal-go
       name: oidc
       env:
-      - name: KEYVAULT_NAME
-        value: ${KEYVAULT_NAME}
+      - name: KEYVAULT_URL
+        value: ${KEYVAULT_URL}
       - name: SECRET_NAME
         value: ${KEYVAULT_SECRET_NAME}
   nodeSelector:


### PR DESCRIPTION
**Reason for Change**:
Update doc to use KEYVAULT_URL, so as to support sovereign clouds

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
Follow-up #561