### PR TITLE
feat: add azure-identity .NET example

### DIFF
--- a/docs/book/src/topics/language-specific-examples/azure-identity-sdk.md
+++ b/docs/book/src/topics/language-specific-examples/azure-identity-sdk.md
@@ -18,3 +18,4 @@ The following client libraries are the **minimum** version required
 | --------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | Python                | [azure-sdk-for-python](https://github.com/Azure/azure-sdk-for-python) | [Link](https://github.com/Azure/azure-workload-identity/tree/main/examples/azure-identity/python) |
 | JavaScript/TypeScript | [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js)         | [Link](https://github.com/Azure/azure-workload-identity/tree/main/examples/azure-identity/node)   |
+| C#                    | [azure-sdk-for-net](https://github.com/Azure/azure-sdk-for-net)       | [Link](https://github.com/Azure/azure-workload-identity/tree/main/examples/azure-identity/dotnet) |

--- a/examples/azure-identity/dotnet/Dockerfile
+++ b/examples/azure-identity/dotnet/Dockerfile
@@ -1,0 +1,12 @@
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:6.0 AS builder
+WORKDIR /app
+ADD . .
+RUN dotnet build akvdotnet.csproj && dotnet publish -c release
+
+ARG BASEIMAGE
+FROM ${BASEIMAGE:-mcr.microsoft.com/dotnet/runtime:6.0}
+WORKDIR /app
+COPY --from=builder /app/bin/release/netcoreapp6.0/publish/ .
+# Kubernetes runAsNonRoot requires USER to be numeric
+USER 65532:65532
+ENTRYPOINT ["dotnet", "akvdotnet.dll"]

--- a/examples/azure-identity/dotnet/Makefile
+++ b/examples/azure-identity/dotnet/Makefile
@@ -1,0 +1,63 @@
+REGISTRY ?= ghcr.io/azure/azure-workload-identity
+IMAGE_NAME := azid-dotnet
+IMAGE_VERSION ?= latest
+
+DEMO_IMAGE := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)
+
+## --------------------------------------
+## Images
+## --------------------------------------
+
+# Output type of docker buildx build
+OUTPUT_TYPE ?= type=registry
+
+ALL_OS = linux windows
+ALL_ARCH.linux = amd64 arm64
+ALL_ARCH.windows = amd64
+ALL_OSVERSIONS.windows := 1809 1903 1909 2004 ltsc2022
+ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
+ALL_OS_ARCH.windows = $(foreach osver, ${ALL_OSVERSIONS.windows}, windows-$(osver)-$(foreach arch, ${ALL_ARCH.windows},$(arch)))
+ALL_OS_ARCH = $(foreach os, $(ALL_OS), ${ALL_OS_ARCH.${os}})
+
+# The architecture of the image
+ARCH ?= amd64
+# OS Version for the Windows images: 1809, 1903, 1909, 2004, ltsc2022
+OSVERSION ?= 1809
+
+.PHONY: container-linux
+container-linux:
+	docker buildx build \
+		--output=$(OUTPUT_TYPE) \
+		--platform="linux/$(ARCH)" \
+		--tag=$(DEMO_IMAGE)-linux-$(ARCH) .
+
+.PHONY: container-windows
+container-windows:
+	docker buildx build \
+		--build-arg BASEIMAGE=mcr.microsoft.com/dotnet/runtime:6.0-nanoserver-${OSVERSION} \
+		--output=$(OUTPUT_TYPE) \
+		--platform="windows/$(ARCH)" \
+		--tag=$(DEMO_IMAGE)-windows-$(OSVERSION)-$(ARCH) .
+
+.PHONY: container-all
+container-all:
+	for arch in $(ALL_ARCH.linux); do \
+		ARCH=$${arch} $(MAKE) container-linux; \
+	done
+	for osversion in $(ALL_OSVERSIONS.windows); do \
+  		OSVERSION=$${osversion} $(MAKE) container-windows; \
+  	done
+
+.PHONY: push-manifest
+push-manifest:
+	docker manifest create --amend $(DEMO_IMAGE) $(foreach osarch, $(ALL_OS_ARCH), $(DEMO_IMAGE)-${osarch})
+	for arch in $(ALL_ARCH.linux); do docker manifest annotate --os linux --arch $${arch} $(DEMO_IMAGE) $(DEMO_IMAGE)-linux-$${arch}; done; \
+	set -x; \
+	for arch in $(ALL_ARCH.windows); do \
+		for osversion in $(ALL_OSVERSIONS.windows); do \
+			BASEIMAGE=mcr.microsoft.com/windows/nanoserver:$${osversion}; \
+			full_version=`docker manifest inspect $${BASEIMAGE} | jq -r '.manifests[0].platform["os.version"]'`; \
+			docker manifest annotate --os windows --arch $${arch} --os-version $${full_version} $(DEMO_IMAGE) $(DEMO_IMAGE)-windows-$${osversion}-$${arch}; \
+		done; \
+	done; \
+	docker manifest push --purge $(DEMO_IMAGE)

--- a/examples/azure-identity/dotnet/Program.cs
+++ b/examples/azure-identity/dotnet/Program.cs
@@ -1,0 +1,28 @@
+// <directives>
+using System;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+// <directives>
+
+namespace akvdotnet
+{
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            Program P = new Program();
+            string keyvaultURL = Environment.GetEnvironmentVariable("KEYVAULT_URL");
+            string secretName = Environment.GetEnvironmentVariable("SECRET_NAME");
+
+            // DefaultAzureCredential will use the environment variables injected by the Azure Workload Identity
+            // mutating webhook to authenticate with Azure Key Vault.
+            SecretClient client = new SecretClient(
+                new Uri(keyvaultURL),
+                new DefaultAzureCredential());
+
+            // <getsecret>
+            var keyvaultSecret = client.GetSecret(secretName).Value;
+            Console.WriteLine("Your secret is " + keyvaultSecret.Value);
+        }
+    }
+}

--- a/examples/azure-identity/dotnet/akvdotnet.csproj
+++ b/examples/azure-identity/dotnet/akvdotnet.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.7.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
part of #187 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
