### PR TITLE
docs: update keyvault command for managed identity in quickstart

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -122,10 +122,9 @@ if using user-assigned managed identity:
 
 ```bash
 export USER_ASSIGNED_IDENTITY_CLIENT_ID="$(az identity show --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --query 'clientId' -otsv)"
-export USER_ASSIGNED_IDENTITY_PRINCIPAL_ID="$(az identity show --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --query 'principalId' -otsv)"
 az keyvault set-policy --name "${KEYVAULT_NAME}" \
   --secret-permissions get \
-  --object-id "${USER_ASSIGNED_IDENTITY_PRINCIPAL_ID}"
+  --spn "${USER_ASSIGNED_IDENTITY_CLIENT_ID}"
 ```
 
 ## 5. Create a Kubernetes service account

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -122,9 +122,10 @@ if using user-assigned managed identity:
 
 ```bash
 export USER_ASSIGNED_IDENTITY_CLIENT_ID="$(az identity show --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --query 'clientId' -otsv)"
+export USER_ASSIGNED_IDENTITY_PRINCIPAL_ID="$(az identity show --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --query 'principalId' -otsv)"
 az keyvault set-policy --name "${KEYVAULT_NAME}" \
   --secret-permissions get \
-  --object-id "${USER_ASSIGNED_IDENTITY_CLIENT_ID}"
+  --object-id "${USER_ASSIGNED_IDENTITY_PRINCIPAL_ID}"
 ```
 
 ## 5. Create a Kubernetes service account


### PR DESCRIPTION
This PR fixes the instructions in step 4 of the quick start guide when using user-assigned managed identities. Specifically, the change is to use the managed identity's `principalId` instead of `clientId` for the `--object-id` parameter when creating the Key Vault security policy.

**Reason for Change**:
The quick start guide didn't work when using user-assigned managed identities. Specifically, I saw 
```console
{"error":{"code":"Forbidden","message":"The user, group or application 'appid=REDACTED-CLIENT_ID;oid=REDACTED-PRINCIPAL_ID;iss=https://sts.windows.net/REDACTED/' does not have secrets 
get permission on key vault 'REDACTED;location=eastus'. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125287","innererror":{"code":"AccessDenied"}}}
```

**Is this a deployment yaml update?**
No

**Are you making changes to the Helm chart?**
No

**Requirements**

- [X] squashed commits
- [X] included documentation
- [ ] added unit tests and e2e tests (if applicable). N/A

**Issue Fixed**:
N/A

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
