### PR TITLE
test: pin default aks cluster version to 1.22

### DIFF
--- a/scripts/create-aks-cluster.sh
+++ b/scripts/create-aks-cluster.sh
@@ -42,8 +42,11 @@ main() {
     timeout --foreground 1200 bash -c register_feature
     echo "Creating an AKS cluster '${CLUSTER_NAME}'"
     LOCATION="$(get_random_region)"
-    # get the latest patch version of 1.23
-    KUBERNETES_VERSION="$(az aks get-versions --location "${LOCATION}" --query 'orchestrators[*].orchestratorVersion' -otsv | grep '1.23' | tail -1)"
+    # get the latest patch version of 1.22
+    # pinning to 1.22 with upgrade to 1.23 because windows agent pool is not supported for k8s version above 1.24.0
+    # ERROR: (AgentPoolK8sVersionNotSupported) windows agentpool is not supported for k8s version above 1.24.0
+    # TODO(aramase): move this to 1.23 or 1.24 after the issue is fixed
+    KUBERNETES_VERSION="$(az aks get-versions --location "${LOCATION}" --query 'orchestrators[*].orchestratorVersion' -otsv | grep '1.22' | tail -1)"
     az group create --name "${CLUSTER_NAME}" --location "${LOCATION}" > /dev/null
     # TODO(chewong): ability to create an arc-enabled cluster
     az aks create \


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
 - Pinning to 1.22 with upgrade to 1.23 because windows agent pool is not supported for k8s version above 1.24.0
 
 ```bash
ERROR: (AgentPoolK8sVersionNotSupported) windows agentpool is not supported for k8s version above 1.24.0
```

fixes failures in nightly CI: https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/results?buildId=59184&view=logs&jobId=7939843a-c18e-59f2-9e98-8c01c1bb1590&j=7939843a-c18e-59f2-9e98-8c01c1bb1590&t=c8e72aab-643b-5650-d9f9-6570bfa55e8f

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
