### PR TITLE
chore: add artifacthub metadata file

### DIFF
--- a/charts/artifacthub-repo.yml
+++ b/charts/artifacthub-repo.yml
@@ -1,0 +1,4 @@
+repositoryID: f968b0bc-fb41-43fd-be93-dc5ef7e0c801
+owners:
+- name: aramase
+  email: anish.ramasekar@gmail.com


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Adds artifacthub metadata file for `Verified Publisher` label (ref: https://artifacthub.io/docs/topics/repositories/#verified-publisher)

Package ref: https://artifacthub.io/packages/helm/azure-workload-identity/workload-identity-webhook

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
