### PR TITLE
AKS installation - check for mutating admission webhook.

### DIFF
--- a/docs/book/src/installation/managed-clusters.md
+++ b/docs/book/src/installation/managed-clusters.md
@@ -17,6 +17,13 @@ To get your cluster's OIDC issuer URL run:
 az aks show --resource-group <resource_group> --name <cluster_name> --query "oidcIssuerProfile.issuerUrl" -otsv
 ```
 
+Ensure your cluster is running a mutating admission webhook. If your cluster is not running a webhook, follow the instructions at [Mutating Admission Webhook](./mutating-admission-webhook.md).
+```bash
+kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io | grep azure-wi-webhook-mutating-webhook-configuration
+# You should see a webhook running
+azure-wi-webhook-mutating-webhook-configuration   1          28m
+```
+
 ## Amazon Elastic Kubernetes Service (EKS)
 
 EKS cluster has an OIDC issuer URL associated with it by default. To get your cluster's OIDC issuer URL run:


### PR DESCRIPTION
**Reason for Change**:
It's not immediately obvious from the AKS installation section that having a mutating admission webhook is required for workload identity to function.


**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
Improve AKS documentation

Does this change contain code from or inspired by another project? **No**

**Notes for Reviewers**:
