### PR TITLE
fix: remove trim suffix from resource_id in proxy

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -186,7 +186,13 @@ func doTokenRequest(ctx context.Context, clientID, resource, tenantID, authority
 		return nil, errors.Wrap(err, "failed to create confidential client app")
 	}
 
-	scope := strings.TrimSuffix(resource, "/")
+	// ref: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/747
+	// For MSAL (v2.0 endpoint) asking an access token for a resource that accepts a v1.0 access token,
+	// Azure AD parses the desired audience from the requested scope by taking everything before the
+	// last slash and using it as the resource identifier.
+	// For example, if the scope is "https://vault.azure.net/.default", the resource identifier is "https://vault.azure.net".
+	// If the scope is "http://database.windows.net//.default", the resource identifier is "http://database.windows.net/".
+	scope := resource
 	if !strings.HasPrefix(scope, "/.default") {
 		scope = scope + "/.default"
 	}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
ref: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/747 For MSAL (v2.0 endpoint) asking an access token for a resource that accepts a v1.0 access token, Azure AD parses the desired audience from the requested scope by taking everything before the last slash and using it as the resource identifier. For example, if the scope is "https://vault.azure.net/.default", the resource identifier is "https://vault.azure.net". If the scope is "http://database.windows.net//.default", the resource identifier is "http://database.windows.net/".


<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
