### PR TITLE
feat: add podLabels to helm charts

### DIFF
--- a/manifest_staging/charts/workload-identity-webhook/README.md
+++ b/manifest_staging/charts/workload-identity-webhook/README.md
@@ -31,7 +31,6 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 
 | Parameter                     | Description                                                                                                                                                          | Default                                                 |
 | :---------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------ |
-| labels                        | The labels to add to the azure-workload-identity webhook pods                                                                                                        | `azure-workload-identity.io/system: "true"`             |
 | replicaCount                  | The number of azure-workload-identity replicas to deploy for the webhook                                                                                             | `2`                                                     |
 | image.repository              | Image repository                                                                                                                                                     | `mcr.microsoft.com/oss/azure/workload-identity/webhook` |
 | image.pullPolicy              | Image pullPolicy                                                                                                                                                     | `IfNotPresent`                                          |
@@ -54,6 +53,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | priorityClassName             | The priority class name for webhook manager                                                                                                                          | `system-cluster-critical`                               |
 | mutatingWebhookObjectSelector | The label selector to further refine which namespaced resources will be selected by the webhook.                                                                     | ``                                                      |
 | mutatingWebhookAnnotations    | The annotations to add to the MutatingWebhookConfiguration                                                                                                           | `{}`                                                    |
+| podLabels                     | The labels to add to the azure-workload-identity webhook pods                                                                                                        | `{}`                                                    |
 
 ## Contributing Changes
 

--- a/manifest_staging/charts/workload-identity-webhook/templates/_helpers.tpl
+++ b/manifest_staging/charts/workload-identity-webhook/templates/_helpers.tpl
@@ -49,3 +49,12 @@ Selector labels
 app.kubernetes.io/name: {{ include "workload-identity-webhook.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Adds the pod labels.
+*/}}
+{{- define "workload-identity-webhook.podLabels" -}}
+{{- if .Values.podLabels }}
+{{- toYaml .Values.podLabels | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-controller-manager-deployment.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+{{- include "workload-identity-webhook.podLabels" . }}
         app: '{{ template "workload-identity-webhook.name" . }}'
         azure-workload-identity.io/system: "true"
         chart: '{{ template "workload-identity-webhook.name" . }}'

--- a/manifest_staging/charts/workload-identity-webhook/values.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-labels:
-  azure-workload-identity.io/system: "true"
 replicaCount: 2
 image:
   repository: mcr.microsoft.com/oss/azure/workload-identity/webhook
@@ -36,3 +34,4 @@ mutatingWebhookFailurePolicy: Ignore
 priorityClassName: system-cluster-critical
 mutatingWebhookObjectSelector: {}
 mutatingWebhookAnnotations: {}
+podLabels: {}

--- a/third_party/open-policy-agent/gatekeeper/helmify/main.go
+++ b/third_party/open-policy-agent/gatekeeper/helmify/main.go
@@ -73,6 +73,10 @@ func (ks *kindSet) Write() error {
 			destFile := path.Join(*outputDir, subPath, fileName)
 			fmt.Printf("Writing %s\n", destFile)
 
+			if kind == "Deployment" {
+				obj = strings.Replace(obj, "      labels:", "      labels:\n{{- include \"workload-identity-webhook.podLabels\" . }}", 1)
+			}
+
 			if err := os.WriteFile(destFile, []byte(obj), 0600); err != nil {
 				return err
 			}

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
@@ -31,7 +31,6 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 
 | Parameter                     | Description                                                                                                                                                          | Default                                                 |
 | :---------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------ |
-| labels                        | The labels to add to the azure-workload-identity webhook pods                                                                                                        | `azure-workload-identity.io/system: "true"`             |
 | replicaCount                  | The number of azure-workload-identity replicas to deploy for the webhook                                                                                             | `2`                                                     |
 | image.repository              | Image repository                                                                                                                                                     | `mcr.microsoft.com/oss/azure/workload-identity/webhook` |
 | image.pullPolicy              | Image pullPolicy                                                                                                                                                     | `IfNotPresent`                                          |
@@ -54,6 +53,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | priorityClassName             | The priority class name for webhook manager                                                                                                                          | `system-cluster-critical`                               |
 | mutatingWebhookObjectSelector | The label selector to further refine which namespaced resources will be selected by the webhook.                                                                     | ``                                                      |
 | mutatingWebhookAnnotations    | The annotations to add to the MutatingWebhookConfiguration                                                                                                           | `{}`                                                    |
+| podLabels                     | The labels to add to the azure-workload-identity webhook pods                                                                                                        | `{}`                                                    |
 
 ## Contributing Changes
 

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/templates/_helpers.tpl
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/templates/_helpers.tpl
@@ -49,3 +49,12 @@ Selector labels
 app.kubernetes.io/name: {{ include "workload-identity-webhook.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Adds the pod labels.
+*/}}
+{{- define "workload-identity-webhook.podLabels" -}}
+{{- if .Values.podLabels }}
+{{- toYaml .Values.podLabels | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-labels:
-  azure-workload-identity.io/system: "true"
 replicaCount: 2
 image:
   repository: mcr.microsoft.com/oss/azure/workload-identity/webhook
@@ -36,3 +34,4 @@ mutatingWebhookFailurePolicy: Ignore
 priorityClassName: system-cluster-critical
 mutatingWebhookObjectSelector: {}
 mutatingWebhookAnnotations: {}
+podLabels: {}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Adds support for configuring labels in the webhook pods.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/551

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
