### PR TITLE
fix: set `expires_in` the proxy token response

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -200,11 +200,12 @@ func doTokenRequest(ctx context.Context, clientID, resource, tenantID, authority
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to acquire token")
 	}
-
 	return &token{
 		AccessToken: result.AccessToken,
 		Resource:    resource,
 		Type:        "Bearer",
+		// -10s is to account for current time changes between the calls
+		ExpiresIn: json.Number(strconv.FormatInt(int64(time.Until(result.ExpiresOn)/time.Second)-10, 10)),
 		// There is a difference in parsing between the azure sdks and how azure-cli works
 		// Using the unix time to be consistent with response from IMDS which works with
 		// all the clients.


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- [msal-go](https://github.com/AzureAD/microsoft-authentication-library-for-go) returns [AuthResult](https://pkg.go.dev/github.com/AzureAD/microsoft-authentication-library-for-go@v0.7.0/apps/internal/base#AuthResult) which doesn't contain the `expires_in` value. Computing that in the proxy based on current time and expires_on. This change is to make the response consistent with the IMDS response and also AAD response for token request.

This is the AAD response:

```json
{
    "token_type": "Bearer",
    "expires_in": 86399,
    "ext_expires_in": 86399,
    "access_token": "<token>"
}
```
xref: https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#successful-response-2

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/624

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
Opened https://github.com/AzureAD/microsoft-authentication-library-for-go/issues/358 to request adding this as part of AuthResult, so we don't have to compute it.