### PR TITLE
docs: Update link to AKS docs for OIDC Issuer

### DIFF
--- a/docs/book/src/installation/managed-clusters.md
+++ b/docs/book/src/installation/managed-clusters.md
@@ -173,4 +173,4 @@ kubectl delete serviceaccount ${SERVICE_ACCOUNT_NAME} -n ${NAMESPACE}
 
 [3]: https://smallstep.com/cli/
 
-[4]: https://docs.microsoft.com/en-us/azure/aks/cluster-configuration#oidc-issuer-preview
+[4]: https://learn.microsoft.com/azure/aks/cluster-configuration#oidc-issuer


### PR DESCRIPTION
**Reason for Change**:
The link to the Azure docs is semi-broken due to the change in the header name. It is also region specific instead of generalized, and uses the old docs subdomain instead of learn.

- Remove preview suffix
- Remove region-specific path
- Switch to new learn platform instead of docs

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
