### PR TITLE
docs: add minimum required permissions for creating federated identity credential

### DIFF
--- a/docs/book/src/faq.md
+++ b/docs/book/src/faq.md
@@ -26,3 +26,28 @@ It takes a few seconds for the federated identity credential to be propagated af
 ## What is the Azure Workload Identity release schedule?
 
 Currently, we release on a monthly basis, targeting the last week of the month.
+
+## What permissions are required to create a federated identity credential for Azure AD Application?
+
+One of the following roles is required:
+
+- [Application Administrator](https://learn.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#application-administrator)
+- [Application Developer](https://learn.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#application-developer)
+- [Cloud Application Administrator](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#cloud-application-administrator)
+- [Application Owner](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#application-owner)
+
+Required permissions to create/update/delete federated identity credential:
+
+- [`microsoft.directory/applications/credentials/update`](https://learn.microsoft.com/en-us/azure/active-directory/roles/custom-available-permissions#microsoftdirectoryapplicationscredentialsupdate)
+
+## What permissions are required to create a federated identity credential for user-assigned managed identity?
+
+One of the following roles is required:
+
+- [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner)
+- [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor)
+
+Required permissions to create/update/delete federated identity credential:
+
+- `Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write`
+- `Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/delete`


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Adds minimum required permissions for creating/deleting/updating federated identity credential with Azure AD Apps and user-assigned managed identity. 

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #548 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
