### PR TITLE
docs: add inline table of contents

### DIFF
--- a/docs/book/src/faq.md
+++ b/docs/book/src/faq.md
@@ -1,5 +1,7 @@
 # Frequently Asked Questions
 
+<!-- toc -->
+
 ## How does the azwi-cli differ from the azure-cli?
 
 The azwi-cli tool is specific to the Azure Workload Identity support in Kubernetes to group several manual steps (e.g. the creation of federated identity credential, annotated service accounts, etc) and automate them. Comparing with the azure-cli, it does not have an official command to add/delete federated identity (configuring federated identity credential with `az rest` is available [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation-create-trust))

--- a/docs/book/src/installation.md
+++ b/docs/book/src/installation.md
@@ -1,5 +1,7 @@
 # Installation
 
+<!-- toc -->
+
 ## Prerequisites
 
 *   [Azure CLI][1] (≥2.32.0)
@@ -15,10 +17,10 @@
 
 ## Azure AD Workload Identity Components
 
-| Component                               | Description                                                                                                                                                                                                            | Guide     |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| Component                               | Description                                                                                                                                                                                                                  | Guide     |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | Mutating Admission Webhook              | Projects a signed service account token to a well-known path (`/var/run/secrets/azure/tokens/azure-identity-token`) and inject authentication-related environment variables to your pods based on annotated service account. | [Link][5] |
-| Azure AD Workload Identity CLI (`azwi`) | A utility CLI that helps manage Azure AD Workload Identity and automate error-prone operations.                                                                                                                        | [Link][6] |
+| Azure AD Workload Identity CLI (`azwi`) | A utility CLI that helps manage Azure AD Workload Identity and automate error-prone operations.                                                                                                                              | [Link][6] |
 
 [1]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 

--- a/docs/book/src/installation/mutating-admission-webhook.md
+++ b/docs/book/src/installation/mutating-admission-webhook.md
@@ -1,5 +1,7 @@
 # Mutating Admission Webhook
 
+<!-- toc -->
+
 Azure AD Workload Identity uses a [mutating admission webhook][1] to project a signed service account token to your workload's volume and inject the following properties to pods with a service account that is configured to use the webhook:
 
 <details>

--- a/docs/book/src/known-issues.md
+++ b/docs/book/src/known-issues.md
@@ -1,5 +1,7 @@
 # Known Issues
 
+<!-- toc -->
+
 ## Permission denied when reading the projected service account token file
 
 In Kubernetes 1.18, the default mode for the projected service account token file is `0600`. This causes containers running as non-root to fail while trying to read the token file:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
Add `<!-- toc -->` in few more docs to autogenerate table of contents

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
