### PR TITLE
fix: use `HasSuffix` check for generating scope

### DIFF
--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -307,3 +307,36 @@ func TestProxy_ReadyZHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestGetScope(t *testing.T) {
+	tests := []struct {
+		name     string
+		scope    string
+		expected string
+	}{
+		{
+			name:     "resource doesn't have /.default suffix",
+			scope:    "https://vault.azure.net",
+			expected: "https://vault.azure.net/.default",
+		},
+		{
+			name:     "resource has /.default suffix",
+			scope:    "https://vault.azure.net/.default",
+			expected: "https://vault.azure.net/.default",
+		},
+		{
+			name:     "resource doesn't  have /.default suffix and has trailing slash",
+			scope:    "https://vault.azure.net/",
+			expected: "https://vault.azure.net//.default",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scope := getScope(test.scope)
+			if scope != test.expected {
+				t.Errorf("expected scope %s, got %s", test.expected, scope)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
