### PR TITLE
ci: enable tests with kubernetes v1.26

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -148,6 +148,8 @@ jobs:
           KIND_NODE_VERSION: v1.24.2
         kind_v1_25_0:
           KIND_NODE_VERSION: v1.25.0
+        kind_v1_26_0:
+          KIND_NODE_VERSION: v1.26.0
     steps:
       - script: make test-e2e
         displayName: Webhook E2E test suite

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -103,6 +103,10 @@ jobs:
           KIND_NODE_VERSION: v1.25.0
           LOCAL_ONLY: "true"
           TEST_HELM_CHART: "true"
+        kind_v1_26_0:
+          KIND_NODE_VERSION: v1.26.0
+          LOCAL_ONLY: "true"
+          TEST_HELM_CHART: "true"
     steps:
       - script: echo "##vso[task.setvariable variable=CLUSTER_NAME]azwi-e2e-$(openssl rand -hex 2)"
         displayName: Set CLUSTER_NAME

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Azure AD Workload Identity is the next iteration of [Azure AD Pod Identity][1] t
 
 | Kubernetes Version | Supported |
 | ------------------ | --------- |
+| 1.26               | ✅         |
 | 1.25               | ✅         |
 | 1.24               | ✅         |
 | 1.23               | ✅         |


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- enable tests with kubernetes v1.26

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
