### PR TITLE
docs: Update quick start doc for user assigned identity

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -122,9 +122,10 @@ if using user-assigned managed identity:
 
 ```bash
 export USER_ASSIGNED_IDENTITY_CLIENT_ID="$(az identity show --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --query 'clientId' -otsv)"
+export USER_ASSIGNED_IDENTITY_OBJECT_ID="$(az identity show --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --query 'principalId' -otsv)"
 az keyvault set-policy --name "${KEYVAULT_NAME}" \
   --secret-permissions get \
-  --spn "${USER_ASSIGNED_IDENTITY_CLIENT_ID}"
+  --object-id "${USER_ASSIGNED_IDENTITY_CLIENT_ID}"
 ```
 
 ## 5. Create a Kubernetes service account

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -125,7 +125,7 @@ export USER_ASSIGNED_IDENTITY_CLIENT_ID="$(az identity show --name "${USER_ASSIG
 export USER_ASSIGNED_IDENTITY_OBJECT_ID="$(az identity show --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --query 'principalId' -otsv)"
 az keyvault set-policy --name "${KEYVAULT_NAME}" \
   --secret-permissions get \
-  --object-id "${USER_ASSIGNED_IDENTITY_CLIENT_ID}"
+  --object-id "${USER_ASSIGNED_IDENTITY_OBJECT_ID}"
 ```
 
 ## 5. Create a Kubernetes service account


### PR DESCRIPTION
Previous code will return `Unable to get object id from principal name.`

**Reason for Change**:
Using `--spn` only works after a period of time ~60s, using `--object-id` works immediately.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
