### PR TITLE
fix: use generate name in logs if pod name is empty

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -99,6 +99,10 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) (respons
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	podName := pod.GetName()
+	if podName == "" {
+		podName = pod.GetGenerateName() + " (prefix)"
+	}
 	// for daemonset/deployment pods the namespace field is not set in objectMeta
 	// explicitly set the namespace to request namespace
 	pod.Namespace = req.Namespace
@@ -110,7 +114,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) (respons
 		serviceAccountName = "default"
 	}
 
-	logger := log.Log.WithName("handler").WithValues("pod", pod.Name, "namespace", pod.Namespace, "service-account", serviceAccountName)
+	logger := log.Log.WithName("handler").WithValues("pod", podName, "namespace", pod.Namespace, "service-account", serviceAccountName)
 	// get service account associated with the pod
 	serviceAccount := &corev1.ServiceAccount{}
 	if err = m.client.Get(ctx, types.NamespacedName{Name: serviceAccountName, Namespace: pod.Namespace}, serviceAccount); err != nil {


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
For static pods, the pod name is not empty. For pods created as part of `Deployments`, `ReplicaSet`, etc, the name is empty and generate name exists.
```console
I0117 22:08:19.736489       1 webhook.go:114] handler "msg"="received pod mutation request pod.GetName()" "namespace"="default" "pod"="" "podName"="" "service-account"="wi"
I0117 22:08:19.736518       1 webhook.go:115] handler "msg"="received pod mutation request pod.GetGenerateName()" "namespace"="default" "pod"="" "podName"="nginx-deployment-84d95667b8-" "service-account"="wi"
```
Actual log with this change

```console
I0117 23:13:27.617001       1 webhook.go:142] handler "msg"="pod not labeled or service account not annotated, skipping mutation" "namespace"="default" "pod"="nginx-deployment-85996f8dbd- (prefix)" "service-account"="default"
```

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/688

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
