### PR TITLE
feat: remove pod/service account labeled check in webhook

### DIFF
--- a/pkg/cmd/podidentity/detect.go
+++ b/pkg/cmd/podidentity/detect.go
@@ -247,13 +247,6 @@ func (dc *detectCmd) createServiceAccountFile(name, ownerName, clientID string) 
 		}
 	}
 
-	saLabels := make(map[string]string)
-	if sa.GetLabels() != nil {
-		saLabels = sa.GetLabels()
-	}
-	saLabels[webhook.UseWorkloadIdentityLabel] = "true"
-	sa.SetLabels(saLabels)
-
 	// set the annotations for the service account
 	saAnnotations := make(map[string]string)
 	if sa.GetAnnotations() != nil {

--- a/pkg/cmd/podidentity/detect_test.go
+++ b/pkg/cmd/podidentity/detect_test.go
@@ -317,9 +317,6 @@ func TestCreateServiceAccountFile(t *testing.T) {
 				t.Errorf("createServiceAccountFile() error = %v, want nil", err)
 			}
 
-			if !strings.Contains(string(gotServiceAccountFile), webhook.UseWorkloadIdentityLabel) {
-				t.Errorf("createServiceAccountFile() file %s does not contain %s, want it to contain it", saFile, webhook.UseWorkloadIdentityLabel)
-			}
 			for _, annotation := range tt.wantedAnnotations {
 				if !strings.Contains(string(gotServiceAccountFile), annotation) {
 					t.Errorf("createServiceAccountFile() file %s does not contain annotation %s, want it to contain it", saFile, annotation)

--- a/pkg/cmd/serviceaccount/phases/create/serviceaccount_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/serviceaccount_test.go
@@ -113,9 +113,6 @@ func TestServiceAccountRun(t *testing.T) {
 	if err = kubeClient.Get(context.TODO(), types.NamespacedName{Name: "service-account-name", Namespace: "service-account-namespace"}, sa); err != nil {
 		t.Errorf("expected service account to be created")
 	}
-	if sa.Labels[webhook.UseWorkloadIdentityLabel] != "true" {
-		t.Errorf("expected service account to have workload identity label but got: %s", sa.Labels[webhook.UseWorkloadIdentityLabel])
-	}
 	if sa.Annotations[webhook.ClientIDAnnotation] != "aad-application-client-id" {
 		t.Errorf("expected service account to have client id annotation but got: %s", sa.Annotations[webhook.ClientIDAnnotation])
 	}

--- a/pkg/kuberneteshelper/serviceaccount.go
+++ b/pkg/kuberneteshelper/serviceaccount.go
@@ -20,9 +20,6 @@ func CreateOrUpdateServiceAccount(ctx context.Context, kubeClient client.Client,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels: map[string]string{
-				webhook.UseWorkloadIdentityLabel: "true",
-			},
 			Annotations: map[string]string{
 				webhook.ClientIDAnnotation: clientID,
 				webhook.TenantIDAnnotation: tenantID,

--- a/pkg/kuberneteshelper/serviceaccount_test.go
+++ b/pkg/kuberneteshelper/serviceaccount_test.go
@@ -42,9 +42,6 @@ func TestCreateOrUpdateServiceAccount(t *testing.T) {
 	if sa.Annotations[webhook.ServiceAccountTokenExpiryAnnotation] != "3601" {
 		t.Errorf("CreateServiceAccount() token expiry annotation = %v, want %v", sa.Annotations[webhook.ServiceAccountTokenExpiryAnnotation], "3601")
 	}
-	if sa.Labels[webhook.UseWorkloadIdentityLabel] != "true" {
-		t.Errorf("CreateServiceAccount() useWorkloadIdentity label = %v, want %v", sa.Labels[webhook.UseWorkloadIdentityLabel], "true")
-	}
 }
 
 func TestCreateOrUpdateServiceAccountDefaultTokenExpiration(t *testing.T) {
@@ -68,9 +65,6 @@ func TestCreateOrUpdateServiceAccountDefaultTokenExpiration(t *testing.T) {
 	}
 	if _, ok := sa.Annotations[webhook.ServiceAccountTokenExpiryAnnotation]; ok {
 		t.Errorf("CreateServiceAccount() token expiry annotation should not be set")
-	}
-	if sa.Labels[webhook.UseWorkloadIdentityLabel] != "true" {
-		t.Errorf("CreateServiceAccount() useWorkloadIdentity label = %v, want %v", sa.Labels[webhook.UseWorkloadIdentityLabel], "true")
 	}
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -30,13 +30,6 @@ var (
 	// ProxyImageVersion is the image version of the proxy init and sidecar.
 	// This is injected via LDFLAGS in the Makefile during the build.
 	ProxyImageVersion string
-
-	PodLabelMissingWarning = fmt.Sprintf(`pod missing label '%s: "true"'. This label will be required in a future release for the webhook to mutate pod. Please add the label to the pod.`, UseWorkloadIdentityLabel)
-)
-
-const (
-	// warningAnnotationKey is the annotation key used to store warning messages in audit annotations
-	warningAnnotationKey = "mutation.azure-workload-identity.io/warning"
 )
 
 // +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=mutation.azure-workload-identity.io,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Equivalent
@@ -89,11 +82,14 @@ func NewPodMutator(client client.Client, reader client.Reader, arcCluster bool, 
 
 // PodMutator adds projected service account volume for incoming pods if service account is annotated
 func (m *podMutator) Handle(ctx context.Context, req admission.Request) (response admission.Response) {
-	warnings := []string{}
-	auditAnnotations := make(map[string]string)
-	pod := &corev1.Pod{}
 	timeStart := time.Now()
+	defer func() {
+		if m.reporter != nil {
+			m.reporter.ReportRequest(ctx, req.Namespace, time.Since(timeStart))
+		}
+	}()
 
+	pod := &corev1.Pod{}
 	err := m.decoder.Decode(req, pod)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
@@ -131,34 +127,6 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) (respons
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 	}
-
-	// mutate pod if the service account or pod is annotated
-	// service account annotated with "azure.workload-identity/use" in annotation or label is current behavior
-	// pod labeled with "azure.workload-identity/use" is added for backward compatibility in v0.15.0 release
-	// This check will eventually be removed in a future release (tentatively v1.0.0-alpha) and all pods will be
-	// mutated. (ref: https://github.com/Azure/azure-workload-identity/issues/601)
-	serviceAccountAnnotated := isServiceAccountAnnotated(serviceAccount)
-	podLabeled := isPodLabeled(pod)
-	shouldMutatePod := serviceAccountAnnotated || podLabeled
-	if !shouldMutatePod {
-		logger.Info("pod not labeled or service account not annotated, skipping mutation")
-		return admission.Allowed("pod not labeled or service account not annotated, skipping mutation")
-	}
-	if !podLabeled {
-		warnings = append(warnings, PodLabelMissingWarning)
-	}
-
-	// only log metrics for the pods that are actually mutated
-	defer func() {
-		if m.reporter != nil {
-			m.reporter.ReportRequest(ctx, req.Namespace, time.Since(timeStart))
-		}
-		response.Warnings = warnings
-		if len(warnings) > 0 {
-			auditAnnotations[warningAnnotationKey] = strings.Join(warnings, ";")
-			response.AuditAnnotations = auditAnnotations
-		}
-	}()
 
 	if shouldInjectProxySidecar(pod) {
 		proxyPort, err := getProxyPort(pod)
@@ -299,22 +267,6 @@ func (m *podMutator) injectProxySidecarContainer(containers []corev1.Container, 
 	})
 
 	return containers
-}
-
-// isServiceAccountAnnotated checks if the service account has been annotated
-// to use with workload identity
-// "azure.workload.identity/use" needs to be available either in annotations or labels
-func isServiceAccountAnnotated(sa *corev1.ServiceAccount) bool {
-	_, isLabeled := sa.Labels[UseWorkloadIdentityLabel]
-	_, isAnnotated := sa.Annotations[UseWorkloadIdentityLabel]
-	return isLabeled || isAnnotated
-}
-
-// isPodLabeled checks if the pod has been labelled to use with workload identity
-// "azure.workload.identity/use" needs to be available either in labels
-func isPodLabeled(pod *corev1.Pod) bool {
-	_, isLabeled := pod.Labels[UseWorkloadIdentityLabel]
-	return isLabeled
 }
 
 func shouldInjectProxySidecar(pod *corev1.Pod) bool {

--- a/test/e2e/webhook.go
+++ b/test/e2e/webhook.go
@@ -3,12 +3,9 @@
 package e2e
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"strings"
-	"sync"
 
 	"github.com/Azure/azure-workload-identity/pkg/webhook"
 
@@ -18,27 +15,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/utils/pointer"
 )
-
-var _ io.Writer = &syncBuffer{}
-
-type syncBuffer struct {
-	lock sync.Mutex
-	buf  bytes.Buffer
-}
-
-func (s *syncBuffer) Write(p []byte) (int, error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	return s.buf.Write(p)
-}
-
-func (s *syncBuffer) String() string {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	return strings.TrimSuffix(s.buf.String(), "\n")
-}
 
 var _ = ginkgo.Describe("Webhook", func() {
 	f := framework.NewDefaultFramework("webhook")


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
With the objectselector set in mwh, only pods that have the label `azure.workload.identity/use: "true"` will be sent to the webhook for mutation. We no longer need the check for pod/service account labeled.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/658

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
