### PR TITLE
chore: complete migration to mlog and drop logrus

### DIFF
--- a/cmd/azwi/main.go
+++ b/cmd/azwi/main.go
@@ -4,14 +4,9 @@ import (
 	"os"
 
 	"github.com/Azure/azure-workload-identity/pkg/cmd"
-
-	colorable "github.com/mattn/go-colorable"
-	log "github.com/sirupsen/logrus" // TODO mlog?
 )
 
 func main() {
-	log.SetFormatter(&log.TextFormatter{ForceColors: true})
-	log.SetOutput(colorable.NewColorableStdout())
 	if err := cmd.NewRootCmd().Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/mattn/go-colorable v0.1.13
 	github.com/microsoft/kiota/abstractions/go v0.0.0-20211202082735-099f3c37853a
 	github.com/microsoft/kiota/authentication/go/azure v0.0.0-20211201125630-3501743a5dc5
 	github.com/microsoft/kiota/serialization/go/json v0.0.0-20211112084539-17ac73ffdc7c
@@ -23,7 +22,6 @@ require (
 	github.com/open-policy-agent/cert-controller v0.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
-	github.com/sirupsen/logrus v1.8.2
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	go.opentelemetry.io/otel v0.20.0
@@ -35,13 +33,13 @@ require (
 	k8s.io/apimachinery v0.25.6
 	k8s.io/client-go v0.25.6
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
-	monis.app/mlog v0.0.2
+	monis.app/mlog v0.0.4
 	sigs.k8s.io/controller-runtime v0.13.1
 )
 
 require (
 	cloud.google.com/go v0.98.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
@@ -76,10 +74,9 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
-	github.com/microsoft/kiota/http/go/nethttp v0.0.0-20211203130928-8449c9e67101 // indirect
-	github.com/microsoftgraph/msgraph-sdk-go-core v0.0.5 // indirect
+	github.com/microsoft/kiota/http/go/nethttp v0.0.0-20211203130928-8449c9e67101
+	github.com/microsoftgraph/msgraph-sdk-go-core v0.0.5
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -387,12 +387,8 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
@@ -525,8 +521,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/sirupsen/logrus v1.8.2 h1:Na+MAUL+cI0P3CtS35fqYIYVL6uKkDYY7sptpCtHHlI=
-github.com/sirupsen/logrus v1.8.2/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
@@ -807,8 +801,6 @@ golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1103,8 +1095,8 @@ k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 h1:MQ8BAZPZlWk3S9K4a9NCkI
 k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1/go.mod h1:C/N6wCaBHeBHkHUesQOQy2/MZqGgMAFPqGsGQLdbZBU=
 k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 h1:KTgPnR10d5zhztWptI952TNtt/4u5h3IzDXkdIMuo2Y=
 k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-monis.app/mlog v0.0.2 h1:zyEt5GsmLhTafXhwidtOFriIVVdejUNc44TzDn/OZc4=
-monis.app/mlog v0.0.2/go.mod h1:LtOpnndFuRGqnLBwzBvpA1DaoKuud2/moLzYXIiNl1s=
+monis.app/mlog v0.0.4 h1:YEzh5sguG4ApywaRWnBU+mGP6SA4WxOqiJ36u+KtoeE=
+monis.app/mlog v0.0.4/go.mod h1:LtOpnndFuRGqnLBwzBvpA1DaoKuud2/moLzYXIiNl1s=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/cloud/graph.go
+++ b/pkg/cloud/graph.go
@@ -10,7 +10,7 @@ import (
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/serviceprincipals"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
+	"monis.app/mlog"
 )
 
 var (
@@ -27,7 +27,7 @@ func (c *AzureClient) CreateServicePrincipal(ctx context.Context, appID string, 
 	spPostOptions.Body.SetAppId(to.StringPtr(appID))
 	spPostOptions.Body.SetTags(tags)
 
-	log.Debugf("Creating service principal for application with id=%s", appID)
+	mlog.Debug("Creating service principal for application", "id", appID)
 	sp, err := c.graphServiceClient.ServicePrincipals().Post(spPostOptions)
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func (c *AzureClient) CreateApplication(ctx context.Context, displayName string)
 	}
 	appPostOptions.Body.SetDisplayName(to.StringPtr(displayName))
 
-	log.Debugf("Creating application with display name=%s", displayName)
+	mlog.Debug("Creating application", "displayName", displayName)
 	app, err := c.graphServiceClient.Applications().Post(appPostOptions)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (c *AzureClient) CreateApplication(ctx context.Context, displayName string)
 
 // GetServicePrincipal gets a service principal by its display name.
 func (c *AzureClient) GetServicePrincipal(ctx context.Context, displayName string) (*graph.ServicePrincipal, error) {
-	log.Debugf("Getting service principal with display name=%s", displayName)
+	mlog.Debug("Getting service principal", "displayName", displayName)
 
 	spGetOptions := &serviceprincipals.ServicePrincipalsRequestBuilderGetOptions{
 		Q: &serviceprincipals.ServicePrincipalsRequestBuilderGetQueryParameters{
@@ -93,7 +93,7 @@ func (c *AzureClient) GetServicePrincipal(ctx context.Context, displayName strin
 
 // GetApplication gets an application by its display name.
 func (c *AzureClient) GetApplication(ctx context.Context, displayName string) (*graph.Application, error) {
-	log.Debugf("Getting application with display name=%s", displayName)
+	mlog.Debug("Getting application", "displayName", displayName)
 
 	appGetOptions := &applications.ApplicationsRequestBuilderGetOptions{
 		Q: &applications.ApplicationsRequestBuilderGetQueryParameters{
@@ -120,19 +120,19 @@ func (c *AzureClient) GetApplication(ctx context.Context, displayName string) (*
 
 // DeleteServicePrincipal deletes a service principal.
 func (c *AzureClient) DeleteServicePrincipal(ctx context.Context, objectID string) error {
-	log.Debugf("Deleting service principal with object id=%s", objectID)
+	mlog.Debug("Deleting service principal", "objectID", objectID)
 	return c.graphServiceClient.ServicePrincipalsById(objectID).Delete(nil)
 }
 
 // DeleteApplication deletes an application.
 func (c *AzureClient) DeleteApplication(ctx context.Context, objectID string) error {
-	log.Debugf("Deleting application with object id=%s", objectID)
+	mlog.Debug("Deleting application", "objectID", objectID)
 	return c.graphServiceClient.ApplicationsById(objectID).Delete(nil)
 }
 
 // AddFederatedCredential adds a federated credential to the cloud provider.
 func (c *AzureClient) AddFederatedCredential(ctx context.Context, objectID string, fic *graph.FederatedIdentityCredential) error {
-	log.Debugf("Adding federated credential for objectID=%s", objectID)
+	mlog.Debug("Adding federated credential", "objectID", objectID)
 
 	ficPostOptions := &federatedidentitycredentials.FederatedIdentityCredentialsRequestBuilderPostOptions{
 		Body: fic,
@@ -153,7 +153,11 @@ func (c *AzureClient) AddFederatedCredential(ctx context.Context, objectID strin
 
 // GetFederatedCredential gets a federated credential from the cloud provider.
 func (c *AzureClient) GetFederatedCredential(ctx context.Context, objectID, issuer, subject string) (*graph.FederatedIdentityCredential, error) {
-	log.Debugf("Getting federated credential for objectID=%s, issuer=%s, subject=%s", objectID, issuer, subject)
+	mlog.Debug("Getting federated credential",
+		"objectID", objectID,
+		"issuer", issuer,
+		"subject", subject,
+	)
 
 	ficGetOptions := &federatedidentitycredentials.FederatedIdentityCredentialsRequestBuilderGetOptions{
 		Q: &federatedidentitycredentials.FederatedIdentityCredentialsRequestBuilderGetQueryParameters{
@@ -183,7 +187,10 @@ func (c *AzureClient) GetFederatedCredential(ctx context.Context, objectID, issu
 
 // DeleteFederatedCredential deletes a federated credential from the cloud provider.
 func (c *AzureClient) DeleteFederatedCredential(ctx context.Context, objectID, federatedCredentialID string) error {
-	log.Debugf("Deleting federated credential for objectID=%s, federatedCredentialID=%s", objectID, federatedCredentialID)
+	mlog.Debug("Deleting federated credential",
+		"objectID", objectID,
+		"federatedCredentialID", federatedCredentialID,
+	)
 	return c.graphServiceClient.ApplicationsById(objectID).FederatedIdentityCredentialsById(federatedCredentialID).Delete(nil)
 }
 

--- a/pkg/cloud/roleassignments.go
+++ b/pkg/cloud/roleassignments.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
+	"monis.app/mlog"
 )
 
 const (
@@ -25,7 +25,10 @@ func (c *AzureClient) CreateRoleAssignment(ctx context.Context, scope, roleName,
 		return result, errors.Wrapf(err, "failed to get role definition id for role %s", roleName)
 	}
 
-	log.Debugf("Creating role assignment for principalID=%s with role=%s", principalID, roleName)
+	mlog.Debug("Creating role assignment",
+		"principalID", principalID,
+		"role", roleName,
+	)
 	parameters := authorization.RoleAssignmentCreateParameters{
 		RoleAssignmentProperties: &authorization.RoleAssignmentProperties{
 			RoleDefinitionID: roleDefinitionID.ID,
@@ -41,7 +44,7 @@ func (c *AzureClient) CreateRoleAssignment(ctx context.Context, scope, roleName,
 			return result, nil
 		}
 		if IsAlreadyExists(err) {
-			log.Warnf("Role assignment already exists for principalID=%s with role=%s", principalID, roleName)
+			mlog.Warning("Role assignment already exists", "principalID", principalID, "role", roleName)
 			return result, err
 		}
 		time.Sleep(roleAssignmentCreateRetryDelay)
@@ -52,6 +55,6 @@ func (c *AzureClient) CreateRoleAssignment(ctx context.Context, scope, roleName,
 
 // DeleteRoleAssignment deletes a role assignment.
 func (c *AzureClient) DeleteRoleAssignment(ctx context.Context, roleAssignmentID string) (authorization.RoleAssignment, error) {
-	log.Debugf("Deleting role assignment with id=%s", roleAssignmentID)
+	mlog.Debug("Deleting role assignment", "id", roleAssignmentID)
 	return c.roleAssignmentsClient.DeleteByID(ctx, roleAssignmentID)
 }

--- a/pkg/cloud/roledefinitions.go
+++ b/pkg/cloud/roledefinitions.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
+	"monis.app/mlog"
 )
 
 // GetRoleDefinitionIDByName returns the role definition ID for the given role name.
 func (c *AzureClient) GetRoleDefinitionIDByName(ctx context.Context, scope, roleName string) (authorization.RoleDefinition, error) {
-	log.Debugf("Get role definition ID by name=%s", roleName)
+	mlog.Debug("Get role definition ID", "name", roleName)
 
 	roleDefinitionList, err := c.roleDefinitionsClient.List(ctx, scope, getRoleNameFilter(roleName))
 	if err != nil {

--- a/pkg/cmd/jwks/root.go
+++ b/pkg/cmd/jwks/root.go
@@ -11,10 +11,10 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	jose "gopkg.in/square/go-jose.v2"
 	"k8s.io/client-go/util/keyutil"
+	"monis.app/mlog"
 )
 
 type jwksCmd struct {
@@ -55,7 +55,7 @@ func (jc *jwksCmd) validate() error {
 }
 
 func (jc *jwksCmd) run() error {
-	log.Debugf("generating JSON Web Key Set for public keys: %v", jc.publicKeys)
+	mlog.Debug("generating JSON Web Key Set", "publicKeys", jc.publicKeys)
 
 	var pubKeys []interface{}
 	for _, file := range jc.publicKeys {
@@ -80,11 +80,11 @@ func (jc *jwksCmd) run() error {
 		if err = os.WriteFile(jc.outputFile, keysetJSON, 0600); err != nil {
 			return errors.Wrap(err, "failed to write JWKS to file")
 		}
-		log.Debugf("wrote JWKS to file: %v", jc.outputFile)
+		mlog.Debug("wrote JWKS", "file", jc.outputFile)
 		return nil
 	}
 
-	log.Debugf("writing JWKS to stdout")
+	mlog.Debug("writing JWKS to stdout")
 	// write the keyset to stdout
 	if _, err = os.Stdout.Write(keysetJSON); err != nil {
 		return errors.Wrap(err, "failed to write JWKS to stdout")

--- a/pkg/cmd/podidentity/root.go
+++ b/pkg/cmd/podidentity/root.go
@@ -10,8 +10,10 @@ func NewPodIdentityCmd() *cobra.Command {
 		Aliases: []string{"pi"},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// run root command pre-run to register the debug flag
-			if cmd.Root() != nil && cmd.Root().PersistentPreRun != nil {
-				cmd.Root().PersistentPreRun(cmd.Root(), args)
+			if cmd.Root() != nil && cmd.Root().PersistentPreRunE != nil {
+				if err := cmd.Root().PersistentPreRunE(cmd.Root(), args); err != nil {
+					return err
+				}
 			}
 			return nil
 		},

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,14 +1,16 @@
 package cmd
 
 import (
+	"context"
+
+	"github.com/spf13/cobra"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // import auth plugins. See https://github.com/Azure/azure-workload-identity/issues/362.
+	"monis.app/mlog"
+
 	"github.com/Azure/azure-workload-identity/pkg/cmd/jwks"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/podidentity"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/version"
-
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	_ "k8s.io/client-go/plugin/pkg/client/auth" // import auth plugins. See https://github.com/Azure/azure-workload-identity/issues/362.
 )
 
 const (
@@ -23,17 +25,32 @@ var (
 
 // NewRootCmd returns the root command for Azure Workload Identity.
 func NewRootCmd() *cobra.Command {
+	flushLogs := mlog.Setup()
 	cmd := &cobra.Command{
 		Use:   rootName,
 		Short: rootShortDescription,
 		Long:  rootLongDescription,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// default to info instead of warning because existing info logs expect to always be printed
+			logLevel := mlog.LevelInfo
 			if debug {
-				log.SetLevel(log.DebugLevel)
+				logLevel = mlog.LevelAll
 			}
+
+			// inputs are essentially static so this should never error
+			return mlog.ValidateAndSetLogLevelAndFormatGlobally(
+				context.Background(), // context is unused with mlog.FormatCLI
+				mlog.LogSpec{
+					Level:  logLevel,
+					Format: mlog.FormatCLI,
+				},
+			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Usage()
+		},
+		PersistentPostRun: func(cmd *cobra.Command, args []string) {
+			flushLogs()
 		},
 	}
 

--- a/pkg/cmd/serviceaccount/auth/provider.go
+++ b/pkg/cmd/serviceaccount/auth/provider.go
@@ -1,18 +1,27 @@
 package auth
 
 import (
+	"crypto/tls"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
-
-	"github.com/Azure/azure-workload-identity/pkg/cloud"
+	"time"
 
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/google/uuid"
+	nethttplibrary "github.com/microsoft/kiota/http/go/nethttp"
+	msgraphbetasdkgo "github.com/microsoftgraph/msgraph-beta-sdk-go"
+	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	ini "gopkg.in/ini.v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+	"monis.app/mlog"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud"
 )
 
 const (
@@ -43,11 +52,87 @@ type authArgs struct {
 	certificatePath string
 	privateKeyPath  string
 	azureClient     cloud.Interface
+
+	client *http.Client
 }
 
 // NewProvider returns a new authArgs
 func NewProvider() Provider {
-	return &authArgs{}
+	return &authArgs{client: defaultClient()}
+}
+
+func defaultClient() *http.Client {
+	return &http.Client{
+		Transport: defaultWrap(defaultTransport()),
+		Timeout:   3 * time.Hour, // make it impossible for requests to hang indefinitely
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse // copied from MS SDK
+		},
+	}
+}
+
+func defaultTransport() *http.Transport {
+	baseRT := http.DefaultTransport.(*http.Transport).Clone()
+	baseRT.MaxIdleConnsPerHost = 25 // copied from client-go
+	baseRT.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12, // same as client-go and MS SDK
+		// enable HTTP2
+		// setting this explicitly is only required in very specific circumstances
+		// it is simpler to just set it here than to try and determine if we need to
+		NextProtos: []string{"h2", "http/1.1"},
+	}
+	utilnet.SetTransportDefaults(baseRT)
+	return baseRT
+}
+
+func defaultWrap(rt http.RoundTripper) http.RoundTripper {
+	opts := msgraphbetasdkgo.GetDefaultClientOptions()
+	rt = newMiddlewarePipeline(msgraphgocore.GetDefaultMiddlewaresWithOptions(&opts), rt)
+	rt = transport.NewUserAgentRoundTripper(rest.DefaultKubernetesUserAgent(), rt)
+	rt = newDelayDebugWrappers(rt)
+	return rt
+}
+
+type delayDebugWrappers struct {
+	transport http.RoundTripper
+}
+
+func newDelayDebugWrappers(rt http.RoundTripper) http.RoundTripper {
+	return &delayDebugWrappers{transport: rt}
+}
+
+func (d *delayDebugWrappers) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt := d.transport
+	if mlog.Enabled(mlog.LevelTrace) {
+		rt = transport.DebugWrappers(rt) // delay wrapping because DebugWrappers makes static checks about log level
+	}
+	return rt.RoundTrip(req)
+}
+
+// copied from MS SDK so we can inject custom base round tripper
+type middlewarePipeline struct {
+	transport   http.RoundTripper
+	middlewares []nethttplibrary.Middleware
+}
+
+func newMiddlewarePipeline(middlewares []nethttplibrary.Middleware, rt http.RoundTripper) http.RoundTripper {
+	return &middlewarePipeline{
+		transport:   rt,
+		middlewares: middlewares,
+	}
+}
+
+func (p *middlewarePipeline) Next(req *http.Request, middlewareIndex int) (*http.Response, error) {
+	if middlewareIndex < len(p.middlewares) {
+		middleware := p.middlewares[middlewareIndex]
+		return middleware.Intercept(p, middlewareIndex+1, req)
+	}
+
+	return p.transport.RoundTrip(req)
+}
+
+func (p *middlewarePipeline) RoundTrip(req *http.Request) (*http.Response, error) {
+	return p.Next(req, 0)
 }
 
 // AddFlags adds the flags for this package to the specified FlagSet
@@ -103,7 +188,7 @@ func (a *authArgs) Validate() error {
 		if err != nil || subID.String() == "00000000-0000-0000-0000-000000000000" {
 			return errors.New("--subscription-id is required (and must be a valid UUID)")
 		}
-		log.Infoln("No subscription provided, using selected subscription from Azure CLI:", subID.String())
+		mlog.Info("No subscription provided, using selected subscription from Azure CLI", "subscriptionID", subID.String())
 		a.subscriptionID = subID
 	}
 
@@ -118,11 +203,11 @@ func (a *authArgs) Validate() error {
 
 	switch a.authMethod {
 	case cliAuthMethod:
-		a.azureClient, err = cloud.NewAzureClientWithCLI(env, a.subscriptionID.String(), a.tenantID)
+		a.azureClient, err = cloud.NewAzureClientWithCLI(env, a.subscriptionID.String(), a.tenantID, a.client)
 	case clientSecretAuthMethod:
-		a.azureClient, err = cloud.NewAzureClientWithClientSecret(env, a.subscriptionID.String(), a.clientID.String(), a.clientSecret, a.tenantID)
+		a.azureClient, err = cloud.NewAzureClientWithClientSecret(env, a.subscriptionID.String(), a.clientID.String(), a.clientSecret, a.tenantID, a.client)
 	case clientCertificateAuthMethod:
-		a.azureClient, err = cloud.NewAzureClientWithClientCertificateFile(env, a.subscriptionID.String(), a.clientID.String(), a.tenantID, a.certificatePath, a.privateKeyPath)
+		a.azureClient, err = cloud.NewAzureClientWithClientCertificateFile(env, a.subscriptionID.String(), a.clientID.String(), a.tenantID, a.certificatePath, a.privateKeyPath, a.client)
 	default:
 		err = errors.Errorf("--auth-method: ERROR: method unsupported. method=%q", a.authMethod)
 	}

--- a/pkg/cmd/serviceaccount/create.go
+++ b/pkg/cmd/serviceaccount/create.go
@@ -5,6 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
+	"github.com/spf13/cobra"
+	"monis.app/mlog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/auth"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/options"
@@ -13,11 +18,6 @@ import (
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/util"
 	"github.com/Azure/azure-workload-identity/pkg/kuberneteshelper"
 	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
-	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func newCreateCmd(authProvider auth.Provider) *cobra.Command {
@@ -117,7 +117,7 @@ func (c *createData) AADApplicationName() string {
 	name := c.aadApplicationName
 	if name == "" {
 		if c.ServiceAccountNamespace() != "" && c.ServiceAccountName() != "" && c.ServiceAccountIssuerURL() != "" {
-			log.Warn("--aad-application-name not specified, constructing name with service account namespace, name, and the hash of the issuer URL")
+			mlog.Warning("--aad-application-name not specified, constructing name with service account namespace, name, and the hash of the issuer URL")
 			name = fmt.Sprintf("%s-%s-%s", c.ServiceAccountNamespace(), c.serviceAccountName, util.GetIssuerHash(c.ServiceAccountIssuerURL()))
 		}
 	}
@@ -133,7 +133,7 @@ func (c *createData) AADApplicationClientID() string {
 
 	app, err := c.AADApplication()
 	if err != nil {
-		log.WithError(err).Error("failed to get AAD application client ID. Returning an empty string")
+		mlog.Error("failed to get AAD application client ID. Returning an empty string", err)
 		return ""
 	}
 	return *app.GetAppId()
@@ -148,7 +148,7 @@ func (c *createData) AADApplicationObjectID() string {
 
 	app, err := c.AADApplication()
 	if err != nil {
-		log.WithError(err).Error("failed to get AAD application object ID. Returning an empty string")
+		mlog.Error("failed to get AAD application object ID. Returning an empty string", err)
 		return ""
 	}
 	return *app.GetId()
@@ -172,7 +172,7 @@ func (c *createData) ServicePrincipalName() string {
 	name := c.servicePrincipalName
 	// fall back to the name of the AAD application
 	if name == "" {
-		log.Warn("--service-principal-name not specified, falling back to AAD application name")
+		mlog.Warning("--service-principal-name not specified, falling back to AAD application name")
 		name = c.AADApplicationName()
 	}
 	return name
@@ -187,7 +187,7 @@ func (c *createData) ServicePrincipalObjectID() string {
 
 	sp, err := c.ServicePrincipal()
 	if err != nil {
-		log.WithError(err).Error("failed to get service principal object ID. Returning an empty string")
+		mlog.Error("failed to get service principal object ID. Returning an empty string", err)
 		return ""
 	}
 	return *sp.GetId()

--- a/pkg/cmd/serviceaccount/create_test.go
+++ b/pkg/cmd/serviceaccount/create_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-workload-identity/pkg/cloud"
-	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
-
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 	"github.com/spf13/pflag"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud"
+	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
 )
 
 const (

--- a/pkg/cmd/serviceaccount/delete.go
+++ b/pkg/cmd/serviceaccount/delete.go
@@ -11,9 +11,9 @@ import (
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/util"
 	"github.com/Azure/azure-workload-identity/pkg/kuberneteshelper"
+	"monis.app/mlog"
 
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -112,7 +112,7 @@ func (d *deleteData) AADApplicationName() string {
 	name := d.aadApplicationName
 	if name == "" {
 		if d.ServiceAccountNamespace() != "" && d.ServiceAccountName() != "" && d.ServiceAccountIssuerURL() != "" {
-			log.Warn("--aad-application-name not specified, constructing name with service account namespace, name, and the hash of the issuer URL")
+			mlog.Warning("--aad-application-name not specified, constructing name with service account namespace, name, and the hash of the issuer URL")
 			name = fmt.Sprintf("%s-%s-%s", d.ServiceAccountNamespace(), d.serviceAccountName, util.GetIssuerHash(d.ServiceAccountIssuerURL()))
 		}
 	}
@@ -128,7 +128,7 @@ func (d *deleteData) AADApplicationObjectID() string {
 
 	app, err := d.AADApplication()
 	if err != nil {
-		log.WithError(err).Error("failed to get AAD application object ID. Returning an empty string")
+		mlog.Error("failed to get AAD application object ID. Returning an empty string", err)
 		return ""
 	}
 	return *app.GetId()

--- a/pkg/cmd/serviceaccount/phases/create/aadapplication.go
+++ b/pkg/cmd/serviceaccount/phases/create/aadapplication.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
+	"monis.app/mlog"
+
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/options"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 	"github.com/Azure/azure-workload-identity/pkg/version"
-
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -64,11 +64,11 @@ func (p *aadApplicationPhase) run(ctx context.Context, data workflow.RunData) er
 		}
 	}
 
-	log.WithFields(log.Fields{
-		"name":     *app.GetDisplayName(),
-		"clientID": *app.GetAppId(),
-		"objectID": *app.GetId(),
-	}).Infof("[%s] created an AAD application", aadApplicationPhaseName)
+	mlog.WithValues(
+		"name", *app.GetDisplayName(),
+		"clientID", *app.GetAppId(),
+		"objectID", *app.GetId(),
+	).WithName(aadApplicationPhaseName).Info("created an AAD application")
 
 	// Check if the service principal with the same name already exists
 	sp, err := createData.ServicePrincipal()
@@ -88,11 +88,11 @@ func (p *aadApplicationPhase) run(ctx context.Context, data workflow.RunData) er
 		}
 	}
 
-	log.WithFields(log.Fields{
-		"name":     *sp.GetDisplayName(),
-		"clientID": *sp.GetAppId(),
-		"objectID": *sp.GetId(),
-	}).Infof("[%s] created service principal", aadApplicationPhaseName)
+	mlog.WithValues(
+		"name", *sp.GetDisplayName(),
+		"clientID", *sp.GetAppId(),
+		"objectID", *sp.GetId(),
+	).WithName(aadApplicationPhaseName).Info("created service principal")
 
 	return nil
 }

--- a/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential.go
+++ b/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
+	"github.com/pkg/errors"
+	"monis.app/mlog"
+
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/options"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/util"
 	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
-	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -81,19 +81,19 @@ func (p *federatedIdentityPhase) run(ctx context.Context, data workflow.RunData)
 	err := createData.AzureClient().AddFederatedCredential(ctx, objectID, fic)
 	if err != nil {
 		if cloud.IsFederatedCredentialAlreadyExists(err) {
-			log.WithFields(log.Fields{
-				"objectID": objectID,
-				"subject":  subject,
-			}).Debugf("[%s] federated credential has been previously created", federatedIdentityPhaseName)
+			mlog.WithValues(
+				"objectID", objectID,
+				"subject", subject,
+			).WithName(federatedIdentityPhaseName).Debug("federated credential has been previously created")
 		} else {
 			return errors.Wrap(err, "failed to add federated credential")
 		}
 	}
 
-	log.WithFields(log.Fields{
-		"objectID": objectID,
-		"subject":  subject,
-	}).Infof("[%s] added federated credential", federatedIdentityPhaseName)
+	mlog.WithValues(
+		"objectID", objectID,
+		"subject", subject,
+	).WithName(federatedIdentityPhaseName).Info("added federated credential")
 
 	return nil
 }

--- a/pkg/cmd/serviceaccount/phases/create/roleassignment.go
+++ b/pkg/cmd/serviceaccount/phases/create/roleassignment.go
@@ -3,12 +3,12 @@ package phases
 import (
 	"context"
 
+	"github.com/pkg/errors"
+	"monis.app/mlog"
+
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/options"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
-
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -62,23 +62,23 @@ func (p *roleAssignmentPhase) run(ctx context.Context, data workflow.RunData) er
 	ra, err := createData.AzureClient().CreateRoleAssignment(ctx, createData.AzureScope(), createData.AzureRole(), createData.ServicePrincipalObjectID())
 	if err != nil {
 		if cloud.IsAlreadyExists(err) {
-			log.WithFields(log.Fields{
-				"scope":                    createData.AzureScope(),
-				"role":                     createData.AzureRole(),
-				"servicePrincipalObjectID": createData.ServicePrincipalObjectID(),
-				"roleAssignmentID":         ra.ID,
-			}).Debugf("[%s] role assignment has previously been created", roleAssignmentPhaseName)
+			mlog.WithValues(
+				"scope", createData.AzureScope(),
+				"role", createData.AzureRole(),
+				"servicePrincipalObjectID", createData.ServicePrincipalObjectID(),
+				"roleAssignmentID", ra.ID,
+			).WithName(roleAssignmentPhaseName).Debug("role assignment has previously been created")
 		} else {
 			return errors.Wrap(err, "failed to create role assignment")
 		}
 	}
 
-	log.WithFields(log.Fields{
-		"scope":                    createData.AzureScope(),
-		"role":                     createData.AzureRole(),
-		"servicePrincipalObjectID": createData.ServicePrincipalObjectID(),
-		"roleAssignmentID":         ra.ID,
-	}).Infof("[%s] created role assignment", roleAssignmentPhaseName)
+	mlog.WithValues(
+		"scope", createData.AzureScope(),
+		"role", createData.AzureRole(),
+		"servicePrincipalObjectID", createData.ServicePrincipalObjectID(),
+		"roleAssignmentID", ra.ID,
+	).WithName(roleAssignmentPhaseName).Info("created role assignment")
 
 	return nil
 }

--- a/pkg/cmd/serviceaccount/phases/create/serviceaccount.go
+++ b/pkg/cmd/serviceaccount/phases/create/serviceaccount.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"time"
 
+	"github.com/pkg/errors"
+	"monis.app/mlog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/options"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 	"github.com/Azure/azure-workload-identity/pkg/kuberneteshelper"
 	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -88,10 +88,10 @@ func (p *serviceAccountPhase) run(ctx context.Context, data workflow.RunData) er
 		return errors.Wrap(err, "failed to create kubernetes service account")
 	}
 
-	log.WithFields(log.Fields{
-		"namespace": createData.ServiceAccountNamespace(),
-		"name":      createData.ServiceAccountName(),
-	}).Infof("[%s] created kubernetes service account", serviceAccountPhaseName)
+	mlog.WithValues(
+		"namespace", createData.ServiceAccountNamespace(),
+		"name", createData.ServiceAccountName(),
+	).WithName(serviceAccountPhaseName).Info("created kubernetes service account")
 
 	return nil
 }

--- a/pkg/cmd/serviceaccount/phases/delete/aadapplication.go
+++ b/pkg/cmd/serviceaccount/phases/delete/aadapplication.go
@@ -3,11 +3,11 @@ package phases
 import (
 	"context"
 
+	"github.com/pkg/errors"
+	"monis.app/mlog"
+
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/options"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
-
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -49,14 +49,14 @@ func (p *aadApplicationPhase) prerun(data workflow.RunData) error {
 func (p *aadApplicationPhase) run(ctx context.Context, data workflow.RunData) error {
 	deleteData := data.(DeleteData)
 
-	l := log.WithFields(log.Fields{
-		"name":     deleteData.AADApplicationName(),
-		"objectID": deleteData.AADApplicationObjectID(),
-	})
+	l := mlog.WithValues(
+		"name", deleteData.AADApplicationName(),
+		"objectID", deleteData.AADApplicationObjectID(),
+	).WithName(aadApplicationPhaseName)
 	if err := deleteData.AzureClient().DeleteApplication(ctx, deleteData.AADApplicationObjectID()); err != nil {
 		return errors.Wrap(err, "failed to delete application")
 	}
-	l.Infof("[%s] deleted aad application", aadApplicationPhaseName)
+	l.Info("deleted aad application")
 
 	return nil
 }

--- a/pkg/cmd/serviceaccount/phases/delete/roleassignment.go
+++ b/pkg/cmd/serviceaccount/phases/delete/roleassignment.go
@@ -3,12 +3,12 @@ package phases
 import (
 	"context"
 
+	"github.com/pkg/errors"
+	"monis.app/mlog"
+
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/options"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
-
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -49,14 +49,16 @@ func (p *roleAssignmentPhase) run(ctx context.Context, data workflow.RunData) er
 
 	// TODO(aramase): consider supporting deletion of role assignment with scope, role and application id
 	// delete the role assignment
-	l := log.WithField("roleAssignmentID", deleteData.RoleAssignmentID())
+	l := mlog.WithValues(
+		"roleAssignmentID", deleteData.RoleAssignmentID(),
+	).WithName(roleAssignmentPhaseName)
 	if _, err := deleteData.AzureClient().DeleteRoleAssignment(ctx, deleteData.RoleAssignmentID()); err != nil {
 		if !cloud.IsRoleAssignmentAlreadyDeleted(err) {
 			return errors.Wrap(err, "failed to delete role assignment")
 		}
-		l.Warnf("[%s] role assignment not found", roleAssignmentPhaseName)
+		l.Warning("role assignment not found")
 	} else {
-		l.Infof("[%s] deleted role assignment", roleAssignmentPhaseName)
+		l.Info("deleted role assignment")
 	}
 
 	return nil

--- a/pkg/cmd/serviceaccount/phases/workflow/runner.go
+++ b/pkg/cmd/serviceaccount/phases/workflow/runner.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"monis.app/mlog"
 )
 
 // RunData contains the data that is passed to the phases
@@ -130,7 +130,7 @@ func (r *runner) Run(data RunData) error {
 	filtered := []Phase{}
 	for _, phase := range r.phases {
 		if skipPhases[phase.Name] {
-			log.WithField("phase", phase.Name).Info("skipping phase")
+			mlog.WithName(phase.Name).Info("skipping phase")
 			continue
 		}
 		filtered = append(filtered, phase)

--- a/pkg/cmd/serviceaccount/root.go
+++ b/pkg/cmd/serviceaccount/root.go
@@ -16,8 +16,10 @@ func NewServiceAccountCmd() *cobra.Command {
 		Aliases: []string{"sa"},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// run root command pre-run to register the debug flag
-			if cmd.Root() != nil && cmd.Root().PersistentPreRun != nil {
-				cmd.Root().PersistentPreRun(cmd.Root(), args)
+			if cmd.Root() != nil && cmd.Root().PersistentPreRunE != nil {
+				if err := cmd.Root().PersistentPreRunE(cmd.Root(), args); err != nil {
+					return err
+				}
 			}
 			return authProvider.Validate()
 		},

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -133,7 +133,7 @@ require (
 	k8s.io/kubectl v0.0.0 // indirect
 	k8s.io/kubelet v0.0.0 // indirect
 	k8s.io/pod-security-admission v0.0.0 // indirect
-	monis.app/mlog v0.0.2 // indirect
+	monis.app/mlog v0.0.4 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.35 // indirect
 	sigs.k8s.io/controller-runtime v0.13.1 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -717,8 +717,8 @@ k8s.io/pod-security-admission v0.25.5 h1:HZLK1Scfdo3/GANlbVHT1vQf1n4lqpfk9Yzi+o8
 k8s.io/pod-security-admission v0.25.5/go.mod h1:m/xoAI1UNWgSviKHLhQc74Bx7A3unH1x1fF1YUOTSps=
 k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 h1:KTgPnR10d5zhztWptI952TNtt/4u5h3IzDXkdIMuo2Y=
 k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-monis.app/mlog v0.0.2 h1:zyEt5GsmLhTafXhwidtOFriIVVdejUNc44TzDn/OZc4=
-monis.app/mlog v0.0.2/go.mod h1:LtOpnndFuRGqnLBwzBvpA1DaoKuud2/moLzYXIiNl1s=
+monis.app/mlog v0.0.4 h1:YEzh5sguG4ApywaRWnBU+mGP6SA4WxOqiJ36u+KtoeE=
+monis.app/mlog v0.0.4/go.mod h1:LtOpnndFuRGqnLBwzBvpA1DaoKuud2/moLzYXIiNl1s=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@microsoft.com>

Fixes #705

Example logs with `--debug`:

```
Wed, 01 Feb 2023 17:43:07 EST  auth/provider.go:191  No subscription provided, using selected subscription from Azure CLI  {"subscription-id": "ID_HERE"}
Wed, 01 Feb 2023 17:43:07 EST  cloud/azureclient.go:235  Resolving tenantID  {"subscriptionID": "ID_HERE"}
Wed, 01 Feb 2023 17:43:07 EST  serviceaccount/delete.go:115  --aad-application-name not specified, constructing name with service account namespace, name, and the hash of the issuer URL  {"warning": true}
Wed, 01 Feb 2023 17:43:07 EST  cloud/graph.go:96  Getting application  {"display name": "default-foo-T"}
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:466  curl -v -XGET  -H "User-Agent: azsdk-go-azidentity/v0.13.2 azsdk-go-azcore/v0.21.0 (go1.19.4; darwin)" 'https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2FID_HERE%2Foauth2%2Fv2.0%2Fauthorize'
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:495  HTTP Trace: DNS Lookup for login.microsoftonline.com resolved to [{20.190.151.9 } {20.190.151.6 } {20.190.151.134 } {20.190.151.70 } {20.190.151.68 } {20.190.151.133 } {20.190.151.8 } {20.190.151.67 }]
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:510  HTTP Trace: Dial to tcp:20.190.151.9:443 succeed
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:553  GET https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https%3A%2F%2Flogin.microsoftonline.com%2FID_HERE%2Foauth2%2Fv2.0%2Fauthorize 200 OK in 157 milliseconds
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:570  HTTP Statistics: DNSLookup 2 ms Dial 21 ms TLSHandshake 51 ms ServerProcessing 82 ms Duration 157 ms
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:577  Response Headers:
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      Strict-Transport-Security: max-age=31536000; includeSubDomains
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      Set-Cookie: COOKIE
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      Client-Request-Id: 51f24826-4e88-47c7-b2a2-0efbcd19bdff
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      X-Ms-Request-Id: ae92df0e-ecfd-4a18-bd95-b3677306fc00
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      X-Content-Type-Options: nosniff
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      Access-Control-Allow-Origin: *
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      P3p: CP="DSP CUR OTPi IND OTRi ONL FIN"
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      X-Xss-Protection: 0
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      Content-Length: 980
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      Cache-Control: max-age=86400, private
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      Access-Control-Allow-Methods: GET, OPTIONS
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      X-Ms-Ests-Server: 2.1.14601.8 - WUS2 ProdSlices
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      Content-Type: application/json; charset=utf-8
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:580      Date: Wed, 01 Feb 2023 22:43:07 GMT
Wed, 01 Feb 2023 17:43:07 EST  transport/round_trippers.go:466  curl -v -XGET  -H "User-Agent: azsdk-go-azidentity/v0.13.2 azsdk-go-azcore/v0.21.0 (go1.19.4; darwin)" 'https://login.microsoftonline.com/ID_HERE/v2.0/.well-known/openid-configuration'
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:553  GET https://login.microsoftonline.com/ID_HERE/v2.0/.well-known/openid-configuration 200 OK in 51 milliseconds
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:570  HTTP Statistics: GetConnection 0 ms ServerProcessing 51 ms Duration 51 ms
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:577  Response Headers:
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Client-Request-Id: 14eb8e3e-b6b0-4790-98d6-308f1b18be92
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      X-Ms-Request-Id: 50171151-8120-40e1-833c-38f04531e400
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      X-Xss-Protection: 0
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Set-Cookie: COOKIE
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      X-Content-Type-Options: nosniff
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      P3p: CP="DSP CUR OTPi IND OTRi ONL FIN"
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Strict-Transport-Security: max-age=31536000; includeSubDomains
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      X-Ms-Ests-Server: 2.1.14601.8 - NCUS ProdSlices
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Date: Wed, 01 Feb 2023 22:43:07 GMT
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Content-Length: 1753
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Access-Control-Allow-Origin: *
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Access-Control-Allow-Methods: GET, OPTIONS
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Cache-Control: max-age=86400, private
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Content-Type: application/json; charset=utf-8
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:466  curl -v -XPOST  -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" -H "Content-Length: 176" -H "User-Agent: azsdk-go-azidentity/v0.13.2 azsdk-go-azcore/v0.21.0 (go1.19.4; darwin)" 'https://login.microsoftonline.com/ID_HERE/oauth2/v2.0/token'
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:553  POST https://login.microsoftonline.com/ID_HERE/oauth2/v2.0/token 400 Bad Request in 212 milliseconds
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:570  HTTP Statistics: GetConnection 0 ms ServerProcessing 211 ms Duration 212 ms
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:577  Response Headers:
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      X-Content-Type-Options: nosniff
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      P3p: CP="DSP CUR OTPi IND OTRi ONL FIN"
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Set-Cookie: COOKIE
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Expires: -1
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Strict-Transport-Security: max-age=31536000; includeSubDomains
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      X-Ms-Request-Id: be8dbd12-e496-499c-a5f4-f4dccb23ea00
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Cache-Control: no-store, no-cache
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Content-Type: application/json; charset=utf-8
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      X-Xss-Protection: 0
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Date: Wed, 01 Feb 2023 22:43:07 GMT
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Content-Length: 752
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Pragma: no-cache
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      Client-Request-Id: 18a4f8ec-abf0-4010-82cb-950870a5aa18
Wed, 01 Feb 2023 17:43:08 EST  transport/round_trippers.go:580      X-Ms-Ests-Server: 2.1.14601.8 - WUS2 ProdSlices
```