### PR TITLE
test: remove sa label check in e2e

### DIFF
--- a/.github/workflows/azwi-e2e.yaml
+++ b/.github/workflows/azwi-e2e.yaml
@@ -75,7 +75,6 @@ jobs:
           # get the service account object
           kubectl describe serviceaccount "${SERVICE_ACCOUNT_NAME}" --namespace "${SERVICE_ACCOUNT_NAMESPACE}" > sa.yaml
 
-          cat sa.yaml | grep "azure.workload.identity/use=true"
           APPLICATION_CLIENT_ID="$(az ad sp list --display-name "${AAD_APPLICATION_NAME}" --query '[0].appId' -otsv)"
           cat sa.yaml | grep "azure.workload.identity/client-id: ${APPLICATION_CLIENT_ID}"
           cat sa.yaml | grep "azure.workload.identity/service-account-token-expiration: 36000"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
resolves `azwi-e2e` failures: https://github.com/Azure/azure-workload-identity/actions/runs/4050485121/jobs/6968544935 as `azwi` no longer annotates the service account.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
