### PR TITLE
docs: update docs for v1.0.0-alpha.0 release

### DIFF
--- a/docs/book/src/known-issues.md
+++ b/docs/book/src/known-issues.md
@@ -45,7 +45,7 @@ az account get-access-token --resource-type=ms-graph
 To bypass this policy:
 
 - `az login` with a user account on a supported system - Windows or MacOS, and make the device compliant.
-- `az login --service-principal` with a service principal which does not have the above compilance check.
+- `az login --service-principal` with a service principal which does not have the above compliance check.
 
 In the case of service principal, you will have to grant the `Application.ReadWrite.All` API permission:
 

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -169,7 +169,7 @@ metadata:
   annotations:
     azure.workload.identity/client-id: ${APPLICATION_CLIENT_ID:-$USER_ASSIGNED_IDENTITY_CLIENT_ID}
   labels:
-    azure.workload.identity/use: "true"
+    azure.workload.identity/use: "true"  # if you're using azure-workload-identity v1.0.0+, this label is not required.
   name: ${SERVICE_ACCOUNT_NAME}
   namespace: ${SERVICE_ACCOUNT_NAMESPACE}
 EOF
@@ -330,7 +330,7 @@ Namespace:    default
 Priority:     0
 Node:         k8s-agentpool1-38097163-vmss000002/10.240.0.34
 Start Time:   Wed, 13 Oct 2021 15:49:25 -0700
-Labels:       <none>
+Labels:       azure.workload.identity/use=true
 Annotations:  <none>
 Status:       Running
 IP:           10.240.0.55

--- a/docs/book/src/topics/self-managed-clusters/service-account-key-rotation.md
+++ b/docs/book/src/topics/self-managed-clusters/service-account-key-rotation.md
@@ -139,14 +139,14 @@ kind: ServiceAccount
 metadata:
   annotations:
     azure.workload.identity/client-id: dummy
-  labels:
-    azure.workload.identity/use: "true"
   name: workload-identity-sa
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   name: dummy-pod
+  labels:
+    azure.workload.identity/use: "true"
 spec:
   serviceAccountName: workload-identity-sa
   containers:

--- a/docs/book/src/topics/service-account-labels-and-annotations.md
+++ b/docs/book/src/topics/service-account-labels-and-annotations.md
@@ -4,13 +4,31 @@
 
 The following is a list of available labels and annotations that can be used to configure the behavior when exchanging the service account token for an AAD access token:
 
+## Pod
+
+### Labels
+
+| Label                         | Description                                                                                                                                                                                                                                                 | Recommended value | Required? |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | --------- |
+| `azure.workload.identity/use` | This label is **required** in the pod template spec. Only pods with this label will be mutated by the azure-workload-identity mutating admission webhook to inject the Azure specific environment variables and the projected service account token volume. | `true`            | ✓         |
+
+### Annotations
+
+| Annotation                                                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   | Default                                   |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `azure.workload.identity/service-account-token-expiration` | **(Takes precedence if the service account is also annotated)** Represents the `expirationSeconds` field for the projected service account token. It is an optional field that the user might want to configure this to prevent any downtime caused by errors during service account token refresh. Kubernetes service account token expiry will not be correlated with AAD tokens. AAD tokens will expire in 24 hours after they are issued. | `3600` (acceptable range: `3600 - 86400`) |
+| `azure.workload.identity/skip-containers`                  | Represents a semi-colon-separated list of containers (e.g. `container1;container2`) to skip adding projected service account token volume. By default, the projected service account token volume will be added to all containers.                                                                                                                                                                                                            |                                           |
+| `azure.workload.identity/inject-proxy-sidecar`             | Injects a proxy init container and proxy sidecar into the pod. The proxy sidecar is used to intercept token requests to IMDS and acquire an AAD token on behalf of the user with federated identity credential.                                                                                                                                                                                                                               | `true`                                    |
+| `azure.workload.identity/proxy-sidecar-port`               | Represents the port of the proxy sidecar.                                                                                                                                                                                                                                                                                                                                                                                                     | `8080`                                    |
+
+
 ## Service Account
 
 ### Labels
 
-| Label                         | Description                                                         | Recommended value | Required? |
-| ----------------------------- | ------------------------------------------------------------------- | ----------------- | --------- |
-| `azure.workload.identity/use` | Represents the service account is to be used for workload identity. | `true`            | ✓         |
+| Label                         | Description                                                         | Recommended value | Required?                                                                         |
+| ----------------------------- | ------------------------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------- |
+| `azure.workload.identity/use` | Represents the service account is to be used for workload identity. | `true`            | **This label is only required if using azure-workload-identity version < v1.0.0** |
 
 ### Annotations
 
@@ -19,22 +37,5 @@ The following is a list of available labels and annotations that can be used to 
 | `azure.workload.identity/client-id`                        | Represents the AAD application client ID to be used with the pod.                                                                                                                                                                                                                                                                                                             |                                                                                                |
 | `azure.workload.identity/tenant-id`                        | Represents the Azure tenant ID where the AAD application is registered.                                                                                                                                                                                                                                                                                                       | `AZURE_TENANT_ID` environment variable extracted from [`azure-wi-webhook-config`][1] ConfigMap |
 | `azure.workload.identity/service-account-token-expiration` | Represents the `expirationSeconds` field for the projected service account token. It is an optional field that the user might want to configure this to prevent any downtime caused by errors during service account token refresh. Kubernetes service account token expiry will not be correlated with AAD tokens. AAD tokens will expire in 24 hours after they are issued. | `3600` (acceptable range: `3600 - 86400`)                                                      |
-
-## Pod
-
-### Labels
-
-| Label                         | Description                                             | Recommended value | Required? |
-| ----------------------------- | ------------------------------------------------------- | ----------------- | --------- |
-| `azure.workload.identity/use` | Represents the pod is to be used for workload identity. | `true`            | ✓         |
-
-### Annotations
-
-| Annotation                                                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   | Default                                   |
-| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `azure.workload.identity/service-account-token-expiration` | **(Takes precedence if the service account is also annotated)** Represents the `expirationSeconds` field for the projected service account token. It is an optional field that the user might want to configure this to prevent any downtime caused by errors during service account token refresh. Kubernetes service account token expiry will not be correlated with AAD tokens. AAD tokens will expire in 24 hours after they are issued. | `3600` (acceptable range: `3600 - 86400`) |
-| `azure.workload.identity/skip-containers`                  | Represents a semi-colon-separated list of containers (e.g. `container1;container2`) to skip adding projected service account token volume. By default, the projected service account token volume will be added to all containers if the service account is labeled with `azure.workload.identity/use: true`.                                                                                                                                 |                                           |
-| `azure.workload.identity/inject-proxy-sidecar`             | Injects a proxy init container and proxy sidecar into the pod. The proxy sidecar is used to intercept token requests to IMDS and acquire an AAD token on behalf of the user with federated identity credential.                                                                                                                                                                                                                               | `true`                                    |
-| `azure.workload.identity/proxy-sidecar-port`               | Represents the port of the proxy sidecar.                                                                                                                                                                                                                                                                                                                                                                                                     | `8080`                                    |
 
 [1]: https://github.com/Azure/azure-workload-identity/blob/40b3842dc49784bb014ad5d8b02cf6c959244196/deploy/azure-wi-webhook.yaml#L101-L110


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Adds note about the required pod label for mutation
- Marks the service account label as required only for `< v1.0.0`. _This section will be removed post `v1.0.0` release._
- Updates troubleshooting guide for possible issue post upgrade to `v1.0.0`. This section will be linked to `Breaking Changes` in the release notes.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
