### PR TITLE
fix: sidecar doesn't work properly for Microsoft ODBC Driver for SQL (#593)

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -57,7 +57,7 @@ type token struct {
 	RefreshToken string `json:"refresh_token"`
 
 	// AAD returns expires_in as a string, ADFS returns it as an int
-	ExpiresIn json.Number `json:"expires_in"`
+	ExpiresIn string `json:"expires_in"`
 	// expires_on can be in two formats, a UTC time stamp or the number of seconds.
 	ExpiresOn string      `json:"expires_on"`
 	NotBefore json.Number `json:"not_before"`
@@ -200,7 +200,7 @@ func doTokenRequest(ctx context.Context, clientID, resource, tenantID, authority
 		Resource:    resource,
 		Type:        "Bearer",
 		// -10s is to account for current time changes between the calls
-		ExpiresIn: json.Number(strconv.FormatInt(int64(time.Until(result.ExpiresOn)/time.Second)-10, 10)),
+		ExpiresIn: strconv.FormatInt(int64(time.Until(result.ExpiresOn)/time.Second)-10, 10),
 		// There is a difference in parsing between the azure sdks and how azure-cli works
 		// Using the unix time to be consistent with response from IMDS which works with
 		// all the clients.


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Proxy defines expires_in as a "number", while odbc drivers expects "string". Because
of this jdbc drivers are failing to parse retrieved token. A bit more details in this [comment](https://github.com/Azure/azure-workload-identity/issues/593#issuecomment-1431307062).

Internally we have replaced proxy to patched version and java jdbc driver started working
properly.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
