### PR TITLE
docs: remove kubernetes version 1.23 (EOL)

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -135,8 +135,6 @@ jobs:
         value: "true"
     strategy:
       matrix:
-        kind_v1_23_6:
-          KIND_NODE_VERSION: v1.23.6
         kind_v1_24_2:
           KIND_NODE_VERSION: v1.24.2
         kind_v1_25_0:

--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -135,10 +135,10 @@ jobs:
         value: "true"
     strategy:
       matrix:
-        kind_v1_24_2:
-          KIND_NODE_VERSION: v1.24.2
-        kind_v1_25_0:
-          KIND_NODE_VERSION: v1.25.0
+        kind_v1_24_7:
+          KIND_NODE_VERSION: v1.24.7
+        kind_v1_25_3:
+          KIND_NODE_VERSION: v1.25.3
         kind_v1_26_0:
           KIND_NODE_VERSION: v1.26.0
     steps:

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -87,12 +87,12 @@ jobs:
         aks_linux:
           REGISTRY: upstream.azurecr.io/azure-workload-identity
           GINKGO_SKIP: \[AKSSoakOnly\]
-        kind_v1_24_2:
-          KIND_NODE_VERSION: v1.24.2
+        kind_v1_24_7:
+          KIND_NODE_VERSION: v1.24.7
           LOCAL_ONLY: "true"
           TEST_HELM_CHART: "true"
-        kind_v1_25_0:
-          KIND_NODE_VERSION: v1.25.0
+        kind_v1_25_3:
+          KIND_NODE_VERSION: v1.25.3
           LOCAL_ONLY: "true"
           TEST_HELM_CHART: "true"
         kind_v1_26_0:

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -87,10 +87,6 @@ jobs:
         aks_linux:
           REGISTRY: upstream.azurecr.io/azure-workload-identity
           GINKGO_SKIP: \[AKSSoakOnly\]
-        kind_v1_23_6:
-          KIND_NODE_VERSION: v1.23.6
-          LOCAL_ONLY: "true"
-          TEST_HELM_CHART: "true"
         kind_v1_24_2:
           KIND_NODE_VERSION: v1.24.2
           LOCAL_ONLY: "true"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Azure AD Workload Identity is the next iteration of [Azure AD Pod Identity][1] t
 | 1.26               | ✅         |
 | 1.25               | ✅         |
 | 1.24               | ✅         |
-| 1.23               | ✅         |
 
 ## Installation
 


### PR DESCRIPTION
- Remove Kubernetes version 1.23 from docs and CI since it has reached EOL
- Update Kubernetes versions to latest in CI for supported releases