### PR TITLE
feat: add graceful shutdown for proxy server

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"monis.app/mlog"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -48,13 +52,31 @@ func mainErr() error {
 		return nil
 	}
 
+	ctx := withShutdownSignal(context.Background())
+
 	p, err := proxy.NewProxy(proxyPort, mlog.New().WithName("proxy"))
 	if err != nil {
 		return fmt.Errorf("setup: failed to create proxy: %w", err)
 	}
-	if err := p.Run(); err != nil {
+	if err := p.Run(ctx); err != nil {
 		return fmt.Errorf("setup: failed to run proxy: %w", err)
 	}
 
 	return nil
+}
+
+// withShutdownSignal returns a copy of the parent context that will close if
+// the process receives termination signals.
+func withShutdownSignal(ctx context.Context) context.Context {
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGTERM, syscall.SIGINT, os.Interrupt)
+
+	nctx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		<-signalChan
+		mlog.Info("received shutdown signal")
+		cancel()
+	}()
+	return nctx
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- add graceful shutdown for proxy server

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
