### PR TITLE
fix: remove unnecessary rbac permissions for mwh

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,22 +11,16 @@ rules:
   resources:
   - serviceaccounts
   verbs:
-  - create
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
   - update
   - watch
 

--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-manager-role-clusterrole.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-manager-role-clusterrole.yaml
@@ -14,21 +14,15 @@ rules:
   resources:
   - serviceaccounts
   verbs:
-  - create
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
   - update
   - watch

--- a/manifest_staging/deploy/azure-wi-webhook.yaml
+++ b/manifest_staging/deploy/azure-wi-webhook.yaml
@@ -54,22 +54,16 @@ rules:
   resources:
   - serviceaccounts
   verbs:
-  - create
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
   - update
   - watch
 ---

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -33,11 +33,11 @@ var (
 )
 
 // +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=mutation.azure-workload-identity.io,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Equivalent
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch
 
 // this is required for the webhook server certs generated and rotated as part of cert-controller rotator
 // +kubebuilder:rbac:groups="",namespace=azure-workload-identity-system,resources=secrets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;list;watch;update
 
 // podMutator mutates pod objects to add project service account token volume
 type podMutator struct {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Remove `CREATE`, `PATCH`, `UPDATE` for service accounts
- Remove `CREATE`, `PATCH`  and `DELETE` for mutating webhook configuration

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
