### PR TITLE
feat: set `reinvocationPolicy: IfNeeded` for webhook

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -16,6 +16,7 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: mutation.azure-workload-identity.io
+  reinvocationPolicy: IfNeeded
   rules:
   - apiGroups:
     - ""

--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -25,6 +25,7 @@ webhooks:
   objectSelector:
     matchLabels:
       azure.workload.identity/use: "true"
+  reinvocationPolicy: IfNeeded
   rules:
   - apiGroups:
     - ""

--- a/manifest_staging/deploy/azure-wi-webhook.yaml
+++ b/manifest_staging/deploy/azure-wi-webhook.yaml
@@ -254,6 +254,7 @@ webhooks:
   objectSelector:
     matchLabels:
       azure.workload.identity/use: "true"
+  reinvocationPolicy: IfNeeded
   rules:
   - apiGroups:
     - ""

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -32,7 +32,7 @@ var (
 	ProxyImageVersion string
 )
 
-// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=mutation.azure-workload-identity.io,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Equivalent
+// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create,versions=v1,name=mutation.azure-workload-identity.io,sideEffects=None,admissionReviewVersions=v1;v1beta1,matchPolicy=Equivalent,reinvocationPolicy=IfNeeded
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch
 
 // this is required for the webhook server certs generated and rotated as part of cert-controller rotator


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- Sets `reinvocationPolicy: IfNeeded` for the workload identity mutating webhook.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #787
fixes #791 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
- Validated this with the [dapr](https://learn.microsoft.com/en-us/azure/aks/dapr) extension.