### PR TITLE
feat: make pod annotations configurable in helm charts

### DIFF
--- a/manifest_staging/charts/workload-identity-webhook/README.md
+++ b/manifest_staging/charts/workload-identity-webhook/README.md
@@ -34,7 +34,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | replicaCount                     | The number of azure-workload-identity replicas to deploy for the webhook                                                          | `2`                                                     |
 | image.repository                 | Image repository                                                                                                                  | `mcr.microsoft.com/oss/azure/workload-identity/webhook` |
 | image.pullPolicy                 | Image pullPolicy                                                                                                                  | `IfNotPresent`                                          |
-| image.release                    | The image release tag to use                                                                                                      | Current release version: `v1.0.0-beta.0`                      |
+| image.release                    | The image release tag to use                                                                                                      | Current release version: `v1.0.0-beta.0`                |
 | imagePullSecrets                 | Image pull secrets to use for retrieving images from private registries                                                           | `[]`                                                    |
 | nodeSelector                     | The node selector to use for pod scheduling                                                                                       | `kubernetes.io/os: linux`                               |
 | resources                        | The resource request/limits for the container image                                                                               | limits: 100m CPU, 30Mi, requests: 100m CPU, 20Mi        |
@@ -51,6 +51,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | priorityClassName                | The priority class name for webhook manager                                                                                       | `system-cluster-critical`                               |
 | mutatingWebhookAnnotations       | The annotations to add to the MutatingWebhookConfiguration                                                                        | `{}`                                                    |
 | podLabels                        | The labels to add to the azure-workload-identity webhook pods                                                                     | `{}`                                                    |
+| podAnnotations                   | The annotations to add to the azure-workload-identity webhook pods                                                                | `{}`                                                    |
 | mutatingWebhookNamespaceSelector | The namespace selector to further refine which namespaces will be selected by the webhook.                                        | `{}`                                                    |
 
 ## Contributing Changes

--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-controller-manager-deployment.yaml
@@ -18,6 +18,8 @@ spec:
       release: '{{ .Release.Name }}'
   template:
     metadata:
+      annotations:
+        {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       labels:
 {{- include "workload-identity-webhook.podLabels" . }}
         app: '{{ template "workload-identity-webhook.name" . }}'

--- a/manifest_staging/charts/workload-identity-webhook/values.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/values.yaml
@@ -32,4 +32,5 @@ metricsBackend: prometheus
 priorityClassName: system-cluster-critical
 mutatingWebhookAnnotations: {}
 podLabels: {}
+podAnnotations: {}
 mutatingWebhookNamespaceSelector: {}

--- a/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/kustomize-for-helm.yaml
@@ -36,6 +36,8 @@ spec:
     metadata:
       labels:
         azure-workload-identity.io/system: "true"
+      annotations:
+        HELMSUBST_POD_ANNOTATIONS: ""
     spec:
       containers:
       - args:

--- a/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
+++ b/third_party/open-policy-agent/gatekeeper/helmify/replacements.go
@@ -31,4 +31,6 @@ imagePullSecrets:
 {{- end }}`,
 
 	`HELMSUBST_MUTATING_WEBHOOK_NAMESPACE_SELECTOR`: `{{- toYaml .Values.mutatingWebhookNamespaceSelector | nindent 4 }}`,
+
+	`HELMSUBST_POD_ANNOTATIONS: ""`: `{{- toYaml .Values.podAnnotations | trim | nindent 8 }}`,
 }

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/README.md
@@ -34,7 +34,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | replicaCount                     | The number of azure-workload-identity replicas to deploy for the webhook                                                          | `2`                                                     |
 | image.repository                 | Image repository                                                                                                                  | `mcr.microsoft.com/oss/azure/workload-identity/webhook` |
 | image.pullPolicy                 | Image pullPolicy                                                                                                                  | `IfNotPresent`                                          |
-| image.release                    | The image release tag to use                                                                                                      | Current release version: `v1.0.0-beta.0`                      |
+| image.release                    | The image release tag to use                                                                                                      | Current release version: `v1.0.0-beta.0`                |
 | imagePullSecrets                 | Image pull secrets to use for retrieving images from private registries                                                           | `[]`                                                    |
 | nodeSelector                     | The node selector to use for pod scheduling                                                                                       | `kubernetes.io/os: linux`                               |
 | resources                        | The resource request/limits for the container image                                                                               | limits: 100m CPU, 30Mi, requests: 100m CPU, 20Mi        |
@@ -51,6 +51,7 @@ helm upgrade -n azure-workload-identity-system [RELEASE_NAME] azure-workload-ide
 | priorityClassName                | The priority class name for webhook manager                                                                                       | `system-cluster-critical`                               |
 | mutatingWebhookAnnotations       | The annotations to add to the MutatingWebhookConfiguration                                                                        | `{}`                                                    |
 | podLabels                        | The labels to add to the azure-workload-identity webhook pods                                                                     | `{}`                                                    |
+| podAnnotations                   | The annotations to add to the azure-workload-identity webhook pods                                                                | `{}`                                                    |
 | mutatingWebhookNamespaceSelector | The namespace selector to further refine which namespaces will be selected by the webhook.                                        | `{}`                                                    |
 
 ## Contributing Changes

--- a/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
+++ b/third_party/open-policy-agent/gatekeeper/helmify/static/values.yaml
@@ -32,4 +32,5 @@ metricsBackend: prometheus
 priorityClassName: system-cluster-critical
 mutatingWebhookAnnotations: {}
 podLabels: {}
+podAnnotations: {}
 mutatingWebhookNamespaceSelector: {}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
- make pod annotations configurable in helm charts

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #789 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
