### PR TITLE
docs: Update AKS OIDC Issuer link

### DIFF
--- a/docs/book/src/installation/managed-clusters.md
+++ b/docs/book/src/installation/managed-clusters.md
@@ -174,4 +174,3 @@ kubectl delete serviceaccount ${SERVICE_ACCOUNT_NAME} -n ${NAMESPACE}
 [3]: https://smallstep.com/cli/
 
 [4]: https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer
-

--- a/docs/book/src/installation/managed-clusters.md
+++ b/docs/book/src/installation/managed-clusters.md
@@ -174,3 +174,4 @@ kubectl delete serviceaccount ${SERVICE_ACCOUNT_NAME} -n ${NAMESPACE}
 [3]: https://smallstep.com/cli/
 
 [4]: https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer
+

--- a/docs/book/src/installation/managed-clusters.md
+++ b/docs/book/src/installation/managed-clusters.md
@@ -173,4 +173,4 @@ kubectl delete serviceaccount ${SERVICE_ACCOUNT_NAME} -n ${NAMESPACE}
 
 [3]: https://smallstep.com/cli/
 
-[4]: https://learn.microsoft.com/azure/aks/cluster-configuration#oidc-issuer
+[4]: https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

When reading the documentation to start using this tool, I noticed that the AKS OIDC documentation link was incorrect. Indeed, the OIDC section apparently was taken away from the original page, and now we have a specific page for it, that is used in this PR.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.

No.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.

No.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [X] no

**Notes for Reviewers**:
Please, let me know if you'd like me to change something in the PR.