### PR TITLE
chore: use goimports for import grouping

### DIFF
--- a/pkg/cmd/podidentity/detect_test.go
+++ b/pkg/cmd/podidentity/detect_test.go
@@ -8,9 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-workload-identity/pkg/cmd/podidentity/k8s"
-	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
 	aadpodv1 "github.com/Azure/aad-pod-identity/pkg/apis/aadpodidentity/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -19,6 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Azure/azure-workload-identity/pkg/cmd/podidentity/k8s"
+	"github.com/Azure/azure-workload-identity/pkg/webhook"
 )
 
 var (

--- a/pkg/cmd/serviceaccount/delete.go
+++ b/pkg/cmd/serviceaccount/delete.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
+	"github.com/spf13/cobra"
+	"monis.app/mlog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/auth"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/options"
@@ -11,11 +16,6 @@ import (
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/util"
 	"github.com/Azure/azure-workload-identity/pkg/kuberneteshelper"
-	"monis.app/mlog"
-
-	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
-	"github.com/spf13/cobra"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (

--- a/pkg/cmd/serviceaccount/delete_test.go
+++ b/pkg/cmd/serviceaccount/delete_test.go
@@ -3,10 +3,10 @@ package serviceaccount
 import (
 	"testing"
 
-	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
-
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
 )
 
 func TestDeleteDataServiceAccountName(t *testing.T) {

--- a/pkg/cmd/serviceaccount/phases/create/aadapplication_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/aadapplication_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
-	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
-
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
+	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 )
 
 func TestAADApplicationPreRun(t *testing.T) {

--- a/pkg/cmd/serviceaccount/phases/create/data.go
+++ b/pkg/cmd/serviceaccount/phases/create/data.go
@@ -3,10 +3,10 @@ package phases
 import (
 	"time"
 
-	"github.com/Azure/azure-workload-identity/pkg/cloud"
-
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud"
 )
 
 // CreateData is the interface to use for create phase.

--- a/pkg/cmd/serviceaccount/phases/create/data_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/data_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-workload-identity/pkg/cloud"
-	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/util"
-
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud"
+	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/util"
 )
 
 type mockCreateData struct {

--- a/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential_test.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
+
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
 	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/util"
 	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
-	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/golang/mock/gomock"
-	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 )
 
 func TestFederatedIdentityPreRun(t *testing.T) {

--- a/pkg/cmd/serviceaccount/phases/create/roleassignment_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/roleassignment_test.go
@@ -5,13 +5,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
-	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
-
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
+	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 )
 
 func TestRoleAssignmentPreRun(t *testing.T) {

--- a/pkg/cmd/serviceaccount/phases/create/serviceaccount_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/serviceaccount_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
-	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
+	"github.com/Azure/azure-workload-identity/pkg/webhook"
 )
 
 func TestServiceAccountPreRun(t *testing.T) {

--- a/pkg/cmd/serviceaccount/phases/delete/aadapplication_test.go
+++ b/pkg/cmd/serviceaccount/phases/delete/aadapplication_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
-	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
-
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
+	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 )
 
 func TestAADApplicationPreRun(t *testing.T) {

--- a/pkg/cmd/serviceaccount/phases/delete/data.go
+++ b/pkg/cmd/serviceaccount/phases/delete/data.go
@@ -1,10 +1,10 @@
 package phases
 
 import (
-	"github.com/Azure/azure-workload-identity/pkg/cloud"
-
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud"
 )
 
 // DeleteData is the interface to use for create phase.

--- a/pkg/cmd/serviceaccount/phases/delete/data_test.go
+++ b/pkg/cmd/serviceaccount/phases/delete/data_test.go
@@ -3,12 +3,12 @@ package phases
 import (
 	"fmt"
 
-	"github.com/Azure/azure-workload-identity/pkg/cloud"
-	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/util"
-
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud"
+	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/util"
 )
 
 type mockDeleteData struct {

--- a/pkg/cmd/serviceaccount/phases/delete/federatedidentitycredential_test.go
+++ b/pkg/cmd/serviceaccount/phases/delete/federatedidentitycredential_test.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-workload-identity/pkg/cloud"
-	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
-	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
-	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/util"
-
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/microsoftgraph/msgraph-beta-sdk-go/models/microsoft/graph"
 	"github.com/pkg/errors"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud"
+	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
+	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
+	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/util"
 )
 
 func TestFederatedIdentityPreRun(t *testing.T) {

--- a/pkg/cmd/serviceaccount/phases/delete/roleassignment_test.go
+++ b/pkg/cmd/serviceaccount/phases/delete/roleassignment_test.go
@@ -5,13 +5,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
-	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
-
 	authorization "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
+
+	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
+	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 )
 
 func TestRoleAssignmentPreRun(t *testing.T) {

--- a/pkg/cmd/serviceaccount/phases/delete/serviceaccount_test.go
+++ b/pkg/cmd/serviceaccount/phases/delete/serviceaccount_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/phases/workflow"
 )
 
 func TestServiceAccountPreRun(t *testing.T) {

--- a/pkg/cmd/serviceaccount/root.go
+++ b/pkg/cmd/serviceaccount/root.go
@@ -1,9 +1,9 @@
 package serviceaccount
 
 import (
-	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/auth"
-
 	"github.com/spf13/cobra"
+
+	"github.com/Azure/azure-workload-identity/pkg/cmd/serviceaccount/auth"
 )
 
 // NewServiceAccountCmd returns a new serviceaccount command

--- a/pkg/cmd/version/root.go
+++ b/pkg/cmd/version/root.go
@@ -3,9 +3,9 @@ package version
 import (
 	"fmt"
 
-	"github.com/Azure/azure-workload-identity/pkg/version"
-
 	"github.com/spf13/cobra"
+
+	"github.com/Azure/azure-workload-identity/pkg/version"
 )
 
 // NewVersionCmd returns a new version command

--- a/pkg/kuberneteshelper/serviceaccount.go
+++ b/pkg/kuberneteshelper/serviceaccount.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/azure-workload-identity/pkg/webhook"
 )
 
 // Create ServiceAccount in the cluster

--- a/pkg/kuberneteshelper/serviceaccount_test.go
+++ b/pkg/kuberneteshelper/serviceaccount_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Azure/azure-workload-identity/pkg/webhook"
 )
 
 const (

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +16,8 @@ import (
 	e2edeploy "k8s.io/kubernetes/test/e2e/framework/deployment"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/utils/pointer"
+
+	"github.com/Azure/azure-workload-identity/pkg/webhook"
 )
 
 const (

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -8,12 +8,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Azure/azure-workload-identity/pkg/webhook"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+
+	"github.com/Azure/azure-workload-identity/pkg/webhook"
 )
 
 // The proxy implementation is only for Linux.

--- a/test/e2e/token_exchange.go
+++ b/test/e2e/token_exchange.go
@@ -7,14 +7,14 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+
+	"github.com/Azure/azure-workload-identity/pkg/webhook"
 )
 
 // Only kind cluster supports custom service account issuer for now.

--- a/test/e2e/webhook.go
+++ b/test/e2e/webhook.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-workload-identity/pkg/webhook"
-
 	"github.com/onsi/ginkgo/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/utils/pointer"
+
+	"github.com/Azure/azure-workload-identity/pkg/webhook"
 )
 
 var _ = ginkgo.Describe("Webhook", func() {


### PR DESCRIPTION
Changed by running `goimports -local github.com/Azure/azure-workload-identity -w .`

fixes #724 