### PR TITLE
chore: update debian-iptables to bullseye-v1.5.4

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=registry.k8s.io/build-image/debian-iptables:bullseye-v1.5.3
+ARG BASEIMAGE=registry.k8s.io/build-image/debian-iptables:bullseye-v1.5.4
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ${BASEIMAGE}
 


### PR DESCRIPTION
- update debian-iptables to bullseye-v1.5.4