### PR TITLE
feat: set security capabilities for azwi-proxy

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -251,6 +251,15 @@ func (m *podMutator) injectProxySidecarContainer(containers []corev1.Container, 
 				},
 			},
 		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: pointer.Bool(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			Privileged:             pointer.Bool(false),
+			ReadOnlyRootFilesystem: pointer.Bool(true),
+			RunAsNonRoot:           pointer.Bool(true),
+		},
 	})
 
 	return containers

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1092,6 +1092,15 @@ func TestInjectProxySidecarContainer(t *testing.T) {
 				},
 			},
 		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: pointer.Bool(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			Privileged:             pointer.Bool(false),
+			ReadOnlyRootFilesystem: pointer.Bool(true),
+			RunAsNonRoot:           pointer.Bool(true),
+		},
 	}
 
 	tests := []struct {


### PR DESCRIPTION
- explicitly set security capabilities for the inject `azwi-proxy` sidecar container

