### PR TITLE
ci: add release branch for pr pipeline

### DIFF
--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -4,6 +4,7 @@ pr:
   branches:
     include:
       - main
+      - release-*
   paths:
     exclude:
     - docs


### PR DESCRIPTION
cherrypick of https://github.com/Azure/azure-workload-identity/pull/819 in `release-1.0` branch