### PR TITLE
ci: enable codeql for pull_request

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    branches:
+    - main
   schedule:
     - cron: "0 7 * * 1" # Mondays at 7:00 AM
 


### PR DESCRIPTION
With the older versions of graph sdk, it took ~ 1h for the action to complete. With the recent upgrades to latest sdk, the action only takes 6-8 mins which is ok to be run.