### PR TITLE
docs: add note about many:1 and 1:many in quick start

### DIFF
--- a/docs/book/src/faq.md
+++ b/docs/book/src/faq.md
@@ -21,6 +21,10 @@ federated identity credentials that reference the same service account in your K
 
 For example, if you are using the [`DefaultAzureCredential`](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) from the Azure Identity Python SDK to authenticate your application, you can specify which identity to use by adding the `managed_identity_client_id` parameter to the `DefaultAzureCredential` constructor.
 
+## How to federate multiple Kubernetes service accounts with a single identity?
+
+It is possible to have a many-to-one relationship between a single identity and multiple Kubernetes service accounts, i.e. you can create a federated identity credential for every <service account namespace, service account name, OIDC issuer> tuple that you want to federate with the same identity.
+
 ## Is there a propagation delay after creating a federated identity credential?
 
 It takes a few seconds for the federated identity credential to be propagated after being initially added. If a token request is made immediately after adding the federated identity credential, it **might** lead to failure for a couple of minutes as the cache is populated in the directory with old data. To avoid this issue, you can add a slight delay after adding the federated identity credential.

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -4,6 +4,10 @@
 
 In this tutorial, we will cover the basics of how to use the webhook to acquire an Azure AD token to access a secret in an [Azure Key Vault][1].
 
+> While this tutorial shows a 1:1 mapping between a Kubernetes service account and an Azure AD identity, it is possible to map:
+> 1. Multiple Kubernetes service accounts to a single Azure AD identity. Refer to [FAQ][15] for more details.
+> 2. Multiple Azure AD identities to a single Kubernetes service account. Refer to [FAQ][16] for more details.
+
 Before we get started, ensure the following:
 
 * Azure CLI version 2.40.0 or higher. Run `az --version` to verify.
@@ -442,3 +446,7 @@ az ad sp delete --id "${APPLICATION_CLIENT_ID}"
 [13]: ./installation.md
 
 [14]: ./known-issues.md#user-tried-to-log-in-to-a-device-from-a-platform-unknown-thats-currently-not-supported-through-conditional-access-policy
+
+[15]: ./faq.md#how-to-federate-multiple-kubernetes-service-accounts-with-a-single-identity
+
+[16]: ./faq.md#how-to-federate-multiple-identities-with-a-kubernetes-service-account


### PR DESCRIPTION
- Add a note about mapping multiple Kubernetes service account to single identity and multiple identities with single Kubernetes service account in FAQ. 
- Also add a reference note in quick start.