### PR TITLE
chore: reenable azwi darwin build as part of release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      # - darwin
+      - darwin
       - linux
       - windows
     goarch:
@@ -22,7 +22,7 @@ builds:
     flags:
       - -mod=vendor
     ldflags:
-      - -s 
+      - -s
       - -w
       - -X {{.ModulePath}}/pkg/version.BuildTime={{.Date}}
       - -X {{.ModulePath}}/pkg/version.BuildVersion={{.Tag}}


### PR DESCRIPTION
- reenable azwi darwin build as part of release
  - It was disabled before because of the build times associated with the msgraph sdk. With the upgrade to latest sdk, the build time is reduced and we should be able to build all `goos`.