### PR TITLE
ci: exclude examples folder from trigger

### DIFF
--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -10,6 +10,9 @@ pr:
     - docs
     - README.md
     - .github
+    - examples/*
+    include:
+    - examples/msal-go/*
 
 pool: staging-pool-amd64-mariner-2
 


### PR DESCRIPTION
- exclude examples folder from CI except for `msal-go` example as that is used for e2e