### PR TITLE
ci: exclude examples folder from trigger (part 2)

### DIFF
--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -12,6 +12,7 @@ pr:
     - .github
     - examples/*
     include:
+    - '*'
     - examples/msal-go/*
 
 pool: staging-pool-amd64-mariner-2


### PR DESCRIPTION
Adding all the files to `include` explicitly 