### PR TITLE
refactor: use odataerrors and azcore response error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/microsoft/kiota-authentication-azure-go v0.6.0
 	github.com/microsoft/kiota-http-go v0.16.2
-	github.com/microsoft/kiota-serialization-json-go v0.9.3
 	github.com/microsoftgraph/msgraph-sdk-go v0.61.0
 	github.com/open-policy-agent/cert-controller v0.5.0
 	github.com/pkg/errors v0.9.1
@@ -39,6 +38,7 @@ require (
 require (
 	github.com/Azure/go-autorest/autorest/adal v0.9.23 // indirect
 	github.com/microsoft/kiota-abstractions-go v0.19.1 // indirect
+	github.com/microsoft/kiota-serialization-json-go v0.9.3 // indirect
 )
 
 require (

--- a/pkg/cloud/azureclient.go
+++ b/pkg/cloud/azureclient.go
@@ -152,18 +152,12 @@ func getClient(env azure.Environment, subscriptionID string, credential azcore.T
 		return nil, errors.Wrap(err, "failed to create request adapter")
 	}
 
-	clientOpts := &armpolicy.ClientOptions{
-		ClientOptions: azcore.ClientOptions{
-			Transport: client,
-		},
-	}
-
-	roleAssignmentsClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, credential, clientOpts)
+	roleAssignmentsClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, credential, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create role assignments client")
 	}
 
-	roleDefinitionsClient, err := armauthorization.NewRoleDefinitionsClient(credential, clientOpts)
+	roleDefinitionsClient, err := armauthorization.NewRoleDefinitionsClient(credential, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create role definitions client")
 	}

--- a/pkg/cloud/errors.go
+++ b/pkg/cloud/errors.go
@@ -5,9 +5,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Azure/go-autorest/autorest"
-	jsonserialization "github.com/microsoft/kiota-serialization-json-go"
-	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/pkg/errors"
 )
 
@@ -20,7 +19,7 @@ const (
 
 // GraphError is a custom error type for Graph API errors.
 type GraphError struct {
-	PublicError *models.PublicError
+	Errorable odataerrors.MainErrorable
 }
 
 // IsNotFound returns true if the given error is a NotFound error.
@@ -31,67 +30,42 @@ func IsNotFound(err error) bool {
 // IsRoleAssignmentAlreadyDeleted returns true if the given error is a role assignment already deleted error.
 // Ref: https://docs.microsoft.com/en-us/rest/api/authorization/role-assignments/delete#response
 func IsRoleAssignmentAlreadyDeleted(err error) bool {
-	derr := autorest.DetailedError{}
+	derr := &azcore.ResponseError{}
 	return errors.As(err, &derr) && derr.StatusCode == http.StatusNoContent
 }
 
-// IsAlreadyExists parses the error message to check if it's resource already exists error.
-func IsAlreadyExists(err error) bool {
-	derr := autorest.DetailedError{}
+// IsRoleAssignmentExists returns true if the given error is a role assignment already exists error.
+func IsRoleAssignmentExists(err error) bool {
+	derr := &azcore.ResponseError{}
 	return errors.As(err, &derr) && derr.StatusCode == http.StatusConflict
 }
 
 // IsFederatedCredentialNotFound returns true if the given error is a federated credential not found error.
 func IsFederatedCredentialNotFound(err error) bool {
 	gerr := GraphError{}
-	return errors.As(err, &gerr) && *gerr.PublicError.GetCode() == GraphErrorCodeResourceNotFound
+	return errors.As(err, &gerr) && *gerr.Errorable.GetCode() == GraphErrorCodeResourceNotFound
 }
 
 // IsFederatedCredentialAlreadyExists returns true if the given error is a federated credential already exists error.
 // E1202 22:40:05.500821  867104 main.go:57] "failed to add federated identity credential" err="code: Request_MultipleObjectsWithSameKeyValue, message: FederatedIdentityCredential with name aramase-default-cred already exists."
 func IsFederatedCredentialAlreadyExists(err error) bool {
 	gerr := GraphError{}
-	return errors.As(err, &gerr) && *gerr.PublicError.GetCode() == GraphErrorCodeMultipleObjectsWithSameKeyValue
+	return errors.As(err, &gerr) && *gerr.Errorable.GetCode() == GraphErrorCodeMultipleObjectsWithSameKeyValue
 }
 
-// GetGraphError returns the public error message from the additional info.
+// maybeExtractGraphError returns the additional information from the graph API error.
 // ref: https://docs.microsoft.com/en-us/graph/errors#error-resource-type
 // errors returned by the graph API aren't serialized today and this is a known issue: https://github.com/microsoftgraph/msgraph-sdk-go-core/issues/1
-func GetGraphError(additionalData map[string]interface{}) (*GraphError, error) {
-	if additionalData == nil || additionalData["error"] == nil {
-		return nil, nil
-	}
-	e := models.NewPublicError()
-	e.SetAdditionalData(additionalData)
-
-	ad := additionalData["error"].(map[string]*jsonserialization.JsonParseNode)
-	// error code string for the error that occurred
-	code, err := ad["code"].GetStringValue()
-	if err != nil {
-		return nil, err
-	}
-	// developer ready message about the error that occurred. This should not be displayed to the user directly.
-	message, err := ad["message"].GetStringValue()
-	if err != nil {
-		return nil, err
-	}
-	// Optional. Additional error objects that may be more specific than the top level error.
-	innerError, err := ad["innerError"].GetObjectValue(models.CreatePublicInnerErrorFromDiscriminatorValue)
-	if err != nil {
-		return nil, err
+func maybeExtractGraphError(err error) error {
+	var oerr *odataerrors.ODataError
+	if errors.As(err, &oerr) {
+		return GraphError{Errorable: oerr.GetError()}
 	}
 
-	e.SetCode(code)
-	e.SetMessage(message)
-	e.SetInnerError(innerError.(*models.PublicInnerError))
-
-	return &GraphError{e}, nil
+	return err
 }
 
 // Error returns the error message.
 func (e GraphError) Error() string {
-	if e.PublicError == nil {
-		return ""
-	}
-	return fmt.Sprintf("code: %s, message: %s", *e.PublicError.GetCode(), *e.PublicError.GetMessage())
+	return fmt.Sprintf("code: %s, message: %s", *e.Errorable.GetCode(), *e.Errorable.GetMessage())
 }

--- a/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential.go
+++ b/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential.go
@@ -84,7 +84,7 @@ func (p *federatedIdentityPhase) run(ctx context.Context, data workflow.RunData)
 			mlog.WithValues(
 				"objectID", objectID,
 				"subject", subject,
-			).WithName(federatedIdentityPhaseName).Debug("federated credential has been previously created")
+			).WithName(federatedIdentityPhaseName).Warning("federated credential has been previously created")
 		} else {
 			return errors.Wrap(err, "failed to add federated credential")
 		}

--- a/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
 	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
@@ -93,9 +94,9 @@ func TestFederatedIdentityRun(t *testing.T) {
 	}
 
 	// Test for scenario where federated credential already exists
-	graphError := cloud.GraphError{PublicError: models.NewPublicError()}
-	graphError.PublicError.SetCode(to.StringPtr(cloud.GraphErrorCodeMultipleObjectsWithSameKeyValue))
-	graphError.PublicError.SetMessage(to.StringPtr("FederatedIdentityCredential with name federatedcredential-from-azwi-cli already exists."))
+	graphError := cloud.GraphError{Errorable: odataerrors.NewMainError()}
+	graphError.Errorable.SetCode(to.StringPtr(cloud.GraphErrorCodeMultipleObjectsWithSameKeyValue))
+	graphError.Errorable.SetMessage(to.StringPtr("FederatedIdentityCredential with name federatedcredential-from-azwi-cli already exists."))
 	mockAzureClient.EXPECT().AddFederatedCredential(gomock.Any(), "aad-application-object-id", gomock.Any()).Return(graphError)
 	err = phase.Run(context.Background(), data)
 	if err != nil {

--- a/pkg/cmd/serviceaccount/phases/create/roleassignment.go
+++ b/pkg/cmd/serviceaccount/phases/create/roleassignment.go
@@ -61,7 +61,7 @@ func (p *roleAssignmentPhase) run(ctx context.Context, data workflow.RunData) er
 	// create the role assignment using object id of the service principal
 	ra, err := createData.AzureClient().CreateRoleAssignment(ctx, createData.AzureScope(), createData.AzureRole(), createData.ServicePrincipalObjectID())
 	if err != nil {
-		if cloud.IsAlreadyExists(err) {
+		if cloud.IsRoleAssignmentExists(err) {
 			mlog.WithValues(
 				"scope", createData.AzureScope(),
 				"role", createData.AzureRole(),

--- a/pkg/cmd/serviceaccount/phases/create/roleassignment_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/roleassignment_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 
@@ -101,7 +101,7 @@ func TestRoleAssignmentRun(t *testing.T) {
 	// Test for scenario where role assignment already exists
 	mockAzureClient.EXPECT().CreateRoleAssignment(context.Background(), data.azureScope, data.azureRole, data.servicePrincipalObjectID).Return(armauthorization.RoleAssignment{
 		ID: to.StringPtr("id"),
-	}, autorest.DetailedError{StatusCode: http.StatusConflict})
+	}, &azcore.ResponseError{StatusCode: http.StatusConflict})
 	if err := phase.Run(context.Background(), data); err != nil {
 		t.Errorf("expected no error but got: %s", err.Error())
 	}

--- a/pkg/cmd/serviceaccount/phases/delete/federatedidentitycredential_test.go
+++ b/pkg/cmd/serviceaccount/phases/delete/federatedidentitycredential_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-workload-identity/pkg/cloud"
@@ -107,9 +108,9 @@ func TestFederatedIdentityRun(t *testing.T) {
 	}
 
 	// Test for scenario where federated credential is not found
-	graphError := cloud.GraphError{PublicError: models.NewPublicError()}
-	graphError.PublicError.SetCode(to.StringPtr(cloud.GraphErrorCodeResourceNotFound))
-	graphError.PublicError.SetMessage(to.StringPtr("FederatedIdentityCredential with name federatedcredential-from-azwi-cli not found."))
+	graphError := cloud.GraphError{Errorable: odataerrors.NewMainError()}
+	graphError.Errorable.SetCode(to.StringPtr(cloud.GraphErrorCodeResourceNotFound))
+	graphError.Errorable.SetMessage(to.StringPtr("FederatedIdentityCredential with name federatedcredential-from-azwi-cli not found."))
 	mockAzureClient.EXPECT().GetFederatedCredential(
 		gomock.Any(),
 		"aad-application-object-id",

--- a/pkg/cmd/serviceaccount/phases/delete/roleassignment_test.go
+++ b/pkg/cmd/serviceaccount/phases/delete/roleassignment_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 
@@ -76,7 +76,7 @@ func TestRoleAssignmentRun(t *testing.T) {
 	}
 
 	// Test for scenario where role assignment is not found
-	mockAzureClient.EXPECT().DeleteRoleAssignment(gomock.Any(), data.roleAssignmentID).Return(armauthorization.RoleAssignment{}, autorest.DetailedError{StatusCode: http.StatusNoContent})
+	mockAzureClient.EXPECT().DeleteRoleAssignment(gomock.Any(), data.roleAssignmentID).Return(armauthorization.RoleAssignment{}, &azcore.ResponseError{StatusCode: http.StatusNoContent})
 	if err := phase.Run(context.Background(), data); err != nil {
 		t.Errorf("expected no error but got: %s", err.Error())
 	}


### PR DESCRIPTION
- Use `odataerrors.ODataError` for graph errors; contains the inner error and other details from additionalData that we were previously parsing because of sdk limitations.
- Use `*azcore.ResponseError` as part of switch to the new sdk for role assignments and role definitions client.

Validated it locally

```console
➜ ./bin/azwi sa create --service-account-name idsa --service-account-namespace oidc --aad-application-name graphtest01 --azure-role Reader --azure-scope "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/aramasedev/providers/Microsoft.KeyVault/vaults/adevkv" --subscription-id <SUBSCRIPTION_ID> --auth-method cli --service-account-issuer-url https://kubernetes.svc.cluster.local
Thu, 04 May 2023 23:52:58 UTC  serviceaccount/create.go:175  --service-principal-name not specified, falling back to AAD application name  {"warning": true}
Thu, 04 May 2023 23:52:59 UTC  aad-application  create/aadapplication.go:71  created an AAD application  {"name": "graphtest01", "clientID": "b27e3f6b-038e-4c51-8872-5f10823d2832", "objectID": "<OBJECT_ID>"}
Thu, 04 May 2023 23:52:59 UTC  serviceaccount/create.go:175  --service-principal-name not specified, falling back to AAD application name  {"warning": true}
Thu, 04 May 2023 23:52:59 UTC  aad-application  create/aadapplication.go:95  created service principal  {"name": "graphtest01", "clientID": "b27e3f6b-038e-4c51-8872-5f10823d2832", "objectID": "<OBJECT_ID>"}
Thu, 04 May 2023 23:52:59 UTC  service-account  create/serviceaccount.go:94  created kubernetes service account  {"namespace": "oidc", "name": "idsa"}
Thu, 04 May 2023 23:52:59 UTC  federated-identity  create/federatedidentitycredential.go:87  federated credential has been previously created  {"objectID": "<OBJECT_ID>", "subject": "system:serviceaccount:oidc:idsa", "warning": true}
Thu, 04 May 2023 23:52:59 UTC  federated-identity  create/federatedidentitycredential.go:96  added federated credential  {"objectID": "<OBJECT_ID>", "subject": "system:serviceaccount:oidc:idsa"}
Thu, 04 May 2023 23:53:01 UTC  cloud/roleassignments.go:50  Role assignment already exists  {"warning": true, "principalID": "<OBJECT_ID>", "role": "Reader"}
Thu, 04 May 2023 23:53:01 UTC  role-assignment  create/roleassignment.go:81  created role assignment  {"scope": "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/aramasedev/providers/Microsoft.KeyVault/vaults/adevkv", "role": "Reader", "servicePrincipalObjectID": "<OBJECT_ID>", "roleAssignmentID": null}
```