### PR TITLE
chore: use `github.com/Azure/azure-sdk-for-go/sdk/azcore/to` instead of `autorest/to`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.19
 
 require (
 	github.com/Azure/aad-pod-identity v1.8.13
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.1.1
 	github.com/Azure/go-autorest/autorest v0.11.29
-	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.9.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
@@ -42,7 +42,6 @@ require (
 )
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/Azure/aad-pod-identity v1.8.13 h1:/gUmacA0z7+lsOlGYAYzkGvAB/KOkUe5Pb6qSeiHD0k=
 github.com/Azure/aad-pod-identity v1.8.13/go.mod h1:uxM/lsPo/abzqdk0rwEm4SqO9pavMz0fCmKpYAj4HL8=
 github.com/Azure/azure-sdk-for-go v57.2.0+incompatible h1:zoJapafogLazoyp0x9aQENzNNqxvU6pnGtb2P8/i+HI=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.5.0 h1:xGLAFFd9D3iLGxYiUGPdITSzsFmU1K8VtfuUHWAoN7M=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.5.0/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0 h1:8kDqDngH+DmVBiCtIjCFTGa7MBnsIOkF9IccInFEbjk=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.2 h1:uqM+VoHjVH6zdlkLF2b6O0ZANcHoj3rO0PoQ3jglUJA=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.2/go.mod h1:twTKAa1E6hLmSDjLhaCkbTMQKc7p/rNLU40rLxGEOCI=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
@@ -58,8 +58,6 @@ github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSY
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/autorest/mocks v0.4.2 h1:PGN4EDXnuQbojHbU0UWoNvmu9AGVwYHG9/fkDYhtAfw=
 github.com/Azure/go-autorest/autorest/mocks v0.4.2/go.mod h1:Vy7OitM9Kei0i1Oj+LvyAWMXJHeKH1MVlzFugfVrmyU=
-github.com/Azure/go-autorest/autorest/to v0.4.0 h1:oXVqrxakqqV1UZdSazDOPOLvOIz+XA683u8EctwboHk=
-github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
 github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+ZtXWSmf4Tg=
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=

--- a/pkg/cloud/graph.go
+++ b/pkg/cloud/graph.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/microsoftgraph/msgraph-sdk-go/applications"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/serviceprincipals"
@@ -21,7 +21,7 @@ var (
 // No secret or certificate is generated.
 func (c *AzureClient) CreateServicePrincipal(ctx context.Context, appID string, tags []string) (models.ServicePrincipalable, error) {
 	body := models.NewServicePrincipal()
-	body.SetAppId(to.StringPtr(appID))
+	body.SetAppId(to.Ptr(appID))
 	body.SetTags(tags)
 
 	mlog.Debug("Creating service principal for application", "id", appID)
@@ -36,7 +36,7 @@ func (c *AzureClient) CreateServicePrincipal(ctx context.Context, appID string, 
 // CreateApplication creates an application.
 func (c *AzureClient) CreateApplication(ctx context.Context, displayName string) (models.Applicationable, error) {
 	body := models.NewApplication()
-	body.SetDisplayName(to.StringPtr(displayName))
+	body.SetDisplayName(to.Ptr(displayName))
 
 	mlog.Debug("Creating application", "displayName", displayName)
 	app, err := c.graphServiceClient.Applications().Post(ctx, body, nil)
@@ -53,7 +53,7 @@ func (c *AzureClient) GetServicePrincipal(ctx context.Context, displayName strin
 
 	spGetOptions := &serviceprincipals.ServicePrincipalsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &serviceprincipals.ServicePrincipalsRequestBuilderGetQueryParameters{
-			Filter: to.StringPtr(getDisplayNameFilter(displayName)),
+			Filter: to.Ptr(getDisplayNameFilter(displayName)),
 		},
 	}
 
@@ -74,7 +74,7 @@ func (c *AzureClient) GetApplication(ctx context.Context, displayName string) (m
 
 	appGetOptions := &applications.ApplicationsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &applications.ApplicationsRequestBuilderGetQueryParameters{
-			Filter: to.StringPtr(getDisplayNameFilter(displayName)),
+			Filter: to.Ptr(getDisplayNameFilter(displayName)),
 		},
 	}
 
@@ -123,7 +123,7 @@ func (c *AzureClient) GetFederatedCredential(ctx context.Context, objectID, issu
 	ficGetOptions := &applications.ItemFederatedIdentityCredentialsRequestBuilderGetRequestConfiguration{
 		QueryParameters: &applications.ItemFederatedIdentityCredentialsRequestBuilderGetQueryParameters{
 			// Filtering on more than one resource is currently not supported.
-			Filter: to.StringPtr(getSubjectFilter(subject)),
+			Filter: to.Ptr(getSubjectFilter(subject)),
 		},
 	}
 

--- a/pkg/cmd/serviceaccount/create_test.go
+++ b/pkg/cmd/serviceaccount/create_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/golang/mock/gomock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/spf13/pflag"
@@ -314,14 +314,14 @@ func TestCreateDataAzureTenantID(t *testing.T) {
 
 func testApplication(appID, objectID string) models.Applicationable {
 	app := models.NewApplication()
-	app.SetAppId(to.StringPtr(appID))
-	app.SetId(to.StringPtr(objectID))
+	app.SetAppId(to.Ptr(appID))
+	app.SetId(to.Ptr(objectID))
 	return app
 }
 
 func testServicePrincipal(appID, objectID string) models.ServicePrincipalable {
 	sp := models.NewServicePrincipal()
-	sp.SetAppId(to.StringPtr(appID))
-	sp.SetId(to.StringPtr(objectID))
+	sp.SetAppId(to.Ptr(appID))
+	sp.SetId(to.Ptr(objectID))
 	return sp
 }

--- a/pkg/cmd/serviceaccount/phases/create/aadapplication_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/aadapplication_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/golang/mock/gomock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 
@@ -82,16 +82,16 @@ func TestAADApplicationRun(t *testing.T) {
 
 func testApplication(appID, objectID, displayName string) models.Applicationable {
 	app := models.NewApplication()
-	app.SetAppId(to.StringPtr(appID))
-	app.SetId(to.StringPtr(objectID))
-	app.SetDisplayName(to.StringPtr(displayName))
+	app.SetAppId(to.Ptr(appID))
+	app.SetId(to.Ptr(objectID))
+	app.SetDisplayName(to.Ptr(displayName))
 	return app
 }
 
 func testServicePrincipal(appID, objectID, displayName string) models.ServicePrincipalable {
 	sp := models.NewServicePrincipal()
-	sp.SetAppId(to.StringPtr(appID))
-	sp.SetId(to.StringPtr(objectID))
-	sp.SetDisplayName(to.StringPtr(displayName))
+	sp.SetAppId(to.Ptr(appID))
+	sp.SetId(to.Ptr(objectID))
+	sp.SetDisplayName(to.Ptr(displayName))
 	return sp
 }

--- a/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential.go
+++ b/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/pkg/errors"
 	"monis.app/mlog"
@@ -73,10 +73,10 @@ func (p *federatedIdentityPhase) run(ctx context.Context, data workflow.RunData)
 	objectID := createData.AADApplicationObjectID()
 	fic := models.NewFederatedIdentityCredential()
 	fic.SetAudiences(audiences)
-	fic.SetDescription(to.StringPtr(description))
-	fic.SetIssuer(to.StringPtr(createData.ServiceAccountIssuerURL()))
-	fic.SetSubject(to.StringPtr(subject))
-	fic.SetName(to.StringPtr(name))
+	fic.SetDescription(to.Ptr(description))
+	fic.SetIssuer(to.Ptr(createData.ServiceAccountIssuerURL()))
+	fic.SetSubject(to.Ptr(subject))
+	fic.SetName(to.Ptr(name))
 
 	err := createData.AzureClient().AddFederatedCredential(ctx, objectID, fic)
 	if err != nil {

--- a/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/federatedidentitycredential_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/golang/mock/gomock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
@@ -79,10 +79,10 @@ func TestFederatedIdentityRun(t *testing.T) {
 
 	fic := models.NewFederatedIdentityCredential()
 	fic.SetAudiences([]string{webhook.DefaultAudience})
-	fic.SetDescription(to.StringPtr(fmt.Sprintf("Federated Service Account for %s/%s", data.serviceAccountNamespace, data.serviceAccountName)))
-	fic.SetIssuer(to.StringPtr(data.serviceAccountIssuerURL))
-	fic.SetSubject(to.StringPtr(util.GetFederatedCredentialSubject(data.serviceAccountNamespace, data.serviceAccountName)))
-	fic.SetName(to.StringPtr(util.GetFederatedCredentialName(data.serviceAccountNamespace, data.serviceAccountName, data.serviceAccountIssuerURL)))
+	fic.SetDescription(to.Ptr(fmt.Sprintf("Federated Service Account for %s/%s", data.serviceAccountNamespace, data.serviceAccountName)))
+	fic.SetIssuer(to.Ptr(data.serviceAccountIssuerURL))
+	fic.SetSubject(to.Ptr(util.GetFederatedCredentialSubject(data.serviceAccountNamespace, data.serviceAccountName)))
+	fic.SetName(to.Ptr(util.GetFederatedCredentialName(data.serviceAccountNamespace, data.serviceAccountName, data.serviceAccountIssuerURL)))
 
 	mockAzureClient := mock_cloud.NewMockInterface(ctrl)
 	mockAzureClient.EXPECT().AddFederatedCredential(gomock.Any(), "aad-application-object-id", fic).Return(nil)
@@ -95,8 +95,8 @@ func TestFederatedIdentityRun(t *testing.T) {
 
 	// Test for scenario where federated credential already exists
 	graphError := cloud.GraphError{Errorable: odataerrors.NewMainError()}
-	graphError.Errorable.SetCode(to.StringPtr(cloud.GraphErrorCodeMultipleObjectsWithSameKeyValue))
-	graphError.Errorable.SetMessage(to.StringPtr("FederatedIdentityCredential with name federatedcredential-from-azwi-cli already exists."))
+	graphError.Errorable.SetCode(to.Ptr(cloud.GraphErrorCodeMultipleObjectsWithSameKeyValue))
+	graphError.Errorable.SetMessage(to.Ptr("FederatedIdentityCredential with name federatedcredential-from-azwi-cli already exists."))
 	mockAzureClient.EXPECT().AddFederatedCredential(gomock.Any(), "aad-application-object-id", gomock.Any()).Return(graphError)
 	err = phase.Run(context.Background(), data)
 	if err != nil {

--- a/pkg/cmd/serviceaccount/phases/create/roleassignment_test.go
+++ b/pkg/cmd/serviceaccount/phases/create/roleassignment_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 
 	"github.com/Azure/azure-workload-identity/pkg/cloud/mock_cloud"
@@ -90,7 +90,7 @@ func TestRoleAssignmentRun(t *testing.T) {
 
 	mockAzureClient := mock_cloud.NewMockInterface(ctrl)
 	mockAzureClient.EXPECT().CreateRoleAssignment(context.Background(), data.azureScope, data.azureRole, data.servicePrincipalObjectID).Return(armauthorization.RoleAssignment{
-		ID: to.StringPtr("id"),
+		ID: to.Ptr("id"),
 	}, nil)
 	data.azureClient = mockAzureClient
 
@@ -100,7 +100,7 @@ func TestRoleAssignmentRun(t *testing.T) {
 
 	// Test for scenario where role assignment already exists
 	mockAzureClient.EXPECT().CreateRoleAssignment(context.Background(), data.azureScope, data.azureRole, data.servicePrincipalObjectID).Return(armauthorization.RoleAssignment{
-		ID: to.StringPtr("id"),
+		ID: to.Ptr("id"),
 	}, &azcore.ResponseError{StatusCode: http.StatusConflict})
 	if err := phase.Run(context.Background(), data); err != nil {
 		t.Errorf("expected no error but got: %s", err.Error())

--- a/pkg/cmd/serviceaccount/phases/delete/federatedidentitycredential_test.go
+++ b/pkg/cmd/serviceaccount/phases/delete/federatedidentitycredential_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/golang/mock/gomock"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
@@ -77,7 +77,7 @@ func TestFederatedIdentityRun(t *testing.T) {
 	defer ctrl.Finish()
 
 	fic := models.NewFederatedIdentityCredential()
-	fic.SetId(to.StringPtr("federated-identity-credential-id"))
+	fic.SetId(to.Ptr("federated-identity-credential-id"))
 
 	mockAzureClient := mock_cloud.NewMockInterface(ctrl)
 	mockAzureClient.EXPECT().GetFederatedCredential(
@@ -109,8 +109,8 @@ func TestFederatedIdentityRun(t *testing.T) {
 
 	// Test for scenario where federated credential is not found
 	graphError := cloud.GraphError{Errorable: odataerrors.NewMainError()}
-	graphError.Errorable.SetCode(to.StringPtr(cloud.GraphErrorCodeResourceNotFound))
-	graphError.Errorable.SetMessage(to.StringPtr("FederatedIdentityCredential with name federatedcredential-from-azwi-cli not found."))
+	graphError.Errorable.SetCode(to.Ptr(cloud.GraphErrorCodeResourceNotFound))
+	graphError.Errorable.SetMessage(to.Ptr("FederatedIdentityCredential with name federatedcredential-from-azwi-cli not found."))
 	mockAzureClient.EXPECT().GetFederatedCredential(
 		gomock.Any(),
 		"aad-application-object-id",


### PR DESCRIPTION
- chore: use `github.com/Azure/azure-sdk-for-go/sdk/azcore/to` instead of `autorest/to`