### PR TITLE
docs: fix markdown syntax in federated identity credentials doc

### DIFF
--- a/docs/book/src/topics/federated-identity-credential.md
+++ b/docs/book/src/topics/federated-identity-credential.md
@@ -9,17 +9,16 @@ Not all service account tokens can be exchanged for a valid AAD token. A federat
 Export the following environment variables:
 
 ```bash
+export SERVICE_ACCOUNT_NAMESPACE="..."
+export SERVICE_ACCOUNT_NAME="..."
+export SERVICE_ACCOUNT_ISSUER="..." # see section 1.1 on how to get the service account issuer url
+
 # if you are using a Azure AD application
 export APPLICATION_NAME="<your application name>"
 
 # if you are using a user-assigned managed identity
 export USER_ASSIGNED_MANAGED_IDENTITY_NAME="<your user-assigned managed identity name>"
 export RESOURCE_GROUP="<your user-assigned managed identity resource group>"
-```
-
-export SERVICE_ACCOUNT_NAMESPACE="..."
-export SERVICE_ACCOUNT_NAME="..."
-export SERVICE_ACCOUNT_ISSUER="..." # see section 1.1 on how to get the service account issuer url
 ```
 
 Currently, there are several ways to create and delete a federated identity credential:


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
The documentation has MarkDown formatting errors. 

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation **(not applicable)**
- [x] added unit tests and e2e tests (if applicable). **(not applicable)**

**Issue Fixed**: None
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no (no code change)

**Notes for Reviewers**: