### PR TITLE
chore: use `dl.k8s.io` instead of hardcoded url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ $(KUSTOMIZE):
 $(KUBECTL):
 	mkdir -p $(TOOLS_BIN_DIR)
 	rm -f "$(KUBECTL)*"
-	curl -sfL https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VER)/bin/$(GOOS)/$(GOARCH)/kubectl -o $(KUBECTL)
+	curl -sfL https://dl.k8s.io/release/$(KUBECTL_VER)/bin/$(GOOS)/$(GOARCH)/kubectl -o $(KUBECTL)
 	ln -sf "$(KUBECTL)" "$(TOOLS_BIN_DIR)/$(KUBECTL_BIN)"
 	chmod +x "$(TOOLS_BIN_DIR)/$(KUBECTL_BIN)" "$(KUBECTL)"
 


### PR DESCRIPTION
The `storage.googleapis.com/kubernetes-release` URL is a hard coded path to a GCS bucket location. To allow redirecting and spreading the load across multiple hosting locations, the `dl.k8s.io` URL has been introduced.

xref: https://github.com/kubernetes/k8s.io/issues/2396