### PR TITLE
docs: fix aad url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Azure AD Workload Identity is an open source project that is [**not** covered by
 <!-- - Ensure backward compatibility when upgrading from [AAD Pod Identity](https://github.com/Azure/aad-pod-identity). -->
 
 [1]: https://github.com/Azure/aad-pod-identity
-[2]: https://azure.microsoft.com/en-us/services/active-directory/
+<!-- markdown-link-check-disable-next-line -->
+[2]: https://azure.microsoft.com/products/active-directory/
 [3]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 [4]: https://azure.github.io/azure-workload-identity/docs/quick-start.html
 [5]: https://azure.github.io/azure-workload-identity/docs/installation/mutating-admission-webhook.html

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -419,7 +419,8 @@ az group delete --name "${RESOURCE_GROUP}"
 az ad sp delete --id "${APPLICATION_CLIENT_ID}"
 ```
 
-[1]: https://azure.microsoft.com/en-us/services/key-vault/
+<!-- markdown-link-check-disable-next-line -->
+[1]: https://azure.microsoft.com/services/key-vault/
 
 [2]: https://kubernetes.io/docs/tasks/tools/
 
@@ -427,7 +428,8 @@ az ad sp delete --id "${APPLICATION_CLIENT_ID}"
 
 [4]: https://www.docker.com/
 
-[5]: https://azure.microsoft.com/en-us/
+<!-- markdown-link-check-disable-next-line -->
+[5]: https://azure.microsoft.com/
 
 [6]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 

--- a/docs/book/src/topics/language-specific-examples.md
+++ b/docs/book/src/topics/language-specific-examples.md
@@ -4,6 +4,7 @@ Azure AD Workload Identity works especially well with the [Azure SDK][1] and the
 
 > You can swap the demo image used in the [quick start](../quick-start.md#7-deploy-workload) with images built from these example projects.
 
-[1]: https://azure.microsoft.com/en-us/downloads/
+<!-- markdown-link-check-disable-next-line -->
+[1]: https://azure.microsoft.com/downloads/
 
-[2]: https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-overview
+[2]: https://docs.microsoft.com/azure/active-directory/develop/msal-overview

--- a/docs/book/src/troubleshooting.md
+++ b/docs/book/src/troubleshooting.md
@@ -70,8 +70,8 @@ export SERVICE_ACCOUNT_ISSUER="<your service account issuer url>" # see section 
 curl ${SERVICE_ACCOUNT_ISSUER}/.well-known/openid-configuration
 curl ${SERVICE_ACCOUNT_ISSUER}/openid/v1/jwks
 ```
-
-If you're seeing this issue with an AKS cluster, to resolve the issue try to reconcile the cluster by running [`az aks update`](https://learn.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest#az-aks-update). If the issue persists after reconciliation, create an [Azure support ticket](https://azure.microsoft.com/en-us/support/create-ticket). 
+<!-- markdown-link-check-disable-next-line -->
+If you're seeing this issue with an AKS cluster, to resolve the issue try to reconcile the cluster by running [`az aks update`](https://learn.microsoft.com/cli/azure/aks?view=azure-cli-latest#az-aks-update). If the issue persists after reconciliation, create an [Azure support ticket](https://azure.microsoft.com/support/create-ticket).
 
 ## Workload pod doesn't have the Azure specific environment variables and projected service account token volume after upgrading to v1.0.0
 


### PR DESCRIPTION
```bash
➜ curl -s -o /dev/null -w "%{http_code}" https://azure.microsoft.com/en-us/services/active-directory/
301

➜ curl -s -o /dev/null -w "%{http_code}" https://azure.microsoft.com/en-us/products/active-directory/
200
```

fixes markdown link failure: https://github.com/Azure/azure-workload-identity/actions/runs/5381004949/jobs/9764511553

 https://azure.microsoft.com/ seems to be failing here. This might be because of some change in the direct behavior, so temporarily disabling the check for that URL.