### PR TITLE
ci: update kubernetes version to v1.26 for aks

### DIFF
--- a/scripts/create-aks-cluster.sh
+++ b/scripts/create-aks-cluster.sh
@@ -26,7 +26,7 @@ main() {
     echo "Creating an AKS cluster '${CLUSTER_NAME}'"
     LOCATION="$(get_random_region)"
     # get the latest patch version of 1.24
-    KUBERNETES_VERSION="$(az aks get-versions --location "${LOCATION}" --query 'orchestrators[*].orchestratorVersion' -otsv | grep '1.24' | tail -1)"
+    KUBERNETES_VERSION="1.26"
     az group create --name "${CLUSTER_NAME}" --location "${LOCATION}" > /dev/null
     # TODO(chewong): ability to create an arc-enabled cluster
     az aks create \


### PR DESCRIPTION
`v1.24` is no longer supported. The AKS LIST versions has API has changed in a backward incompatible way. It no longer has `orchestrators[*].orchestratorVersion`. Refer to https://learn.microsoft.com/en-us/rest/api/aks/managed-clusters/list-kubernetes-versions?tabs=HTTP#kubernetesversionlistresult for sample result. 