### PR TITLE
fix: Prepend proxy sidecar container to prevent application container restarts

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -233,7 +233,7 @@ func (m *podMutator) injectProxySidecarContainer(containers []corev1.Container, 
 	}
 
 	logLevel := currentLogLevel() // run the proxy at the same log level as the webhook
-	containers = append(containers, corev1.Container{
+	containers = append([]corev1.Container{{
 		Name:            ProxySidecarContainerName,
 		Image:           strings.Join([]string{imageRepository, ProxyImageVersion}, ":"),
 		ImagePullPolicy: corev1.PullIfNotPresent,
@@ -265,7 +265,7 @@ func (m *podMutator) injectProxySidecarContainer(containers []corev1.Container, 
 			ReadOnlyRootFilesystem: pointer.Bool(true),
 			RunAsNonRoot:           pointer.Bool(true),
 		},
-	})
+	}}, containers...)
 
 	return containers
 }


### PR DESCRIPTION
**Reason for Change**:
To fix application container startup errors due to incorrect container ordering (proxy sidecar will be triggered last instead of first).

**Issue Fixed**:
Fixes #1101
