### PR TITLE
fix: prepend proxy sidecar container to prevent application container restarts

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -233,7 +233,7 @@ func (m *podMutator) injectProxySidecarContainer(containers []corev1.Container, 
 	}
 
 	logLevel := currentLogLevel() // run the proxy at the same log level as the webhook
-	containers = append(containers, corev1.Container{
+	containers = append([]corev1.Container{{
 		Name:            ProxySidecarContainerName,
 		Image:           strings.Join([]string{imageRepository, ProxyImageVersion}, ":"),
 		ImagePullPolicy: corev1.PullIfNotPresent,
@@ -265,7 +265,7 @@ func (m *podMutator) injectProxySidecarContainer(containers []corev1.Container, 
 			ReadOnlyRootFilesystem: pointer.Bool(true),
 			RunAsNonRoot:           pointer.Bool(true),
 		},
-	})
+	}}, containers...)
 
 	return containers
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1128,11 +1128,11 @@ func TestInjectProxySidecarContainer(t *testing.T) {
 				},
 			},
 			expectedContainers: []corev1.Container{
+				proxySidecarContainer,
 				{
 					Name:  "my-container",
 					Image: "my-image",
 				},
-				proxySidecarContainer,
 			},
 		},
 	}


### PR DESCRIPTION
To fix application container startup errors due to incorrect container ordering (proxy sidecar will be triggered last instead of first).

fixes #1101

This PR builds on top of https://github.com/Azure/azure-workload-identity/pull/1102 and fixes the unit tests.