### PR TITLE
chore: update distroless-iptables to v0.4.1

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.k8s.io/build-image/distroless-iptables:v0.2.5
+FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.k8s.io/build-image/distroless-iptables:v0.4.1
 
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh


### PR DESCRIPTION
- update distroless-iptables to `v0.4.1`
  - resolves base image CVEs: https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/results?buildId=131577&view=logs&jobId=50e5c204-a982-5a63-4824-cf22f1b24a4e&j=50e5c204-a982-5a63-4824-cf22f1b24a4e&t=94cd4644-8683-57bb-f7f8-715cbe70e34e