### PR TITLE
Updated the quick start guide to include details on --enable-workload…

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -18,7 +18,8 @@ Before we get started, ensure the following:
 ## 1. Complete the installation guide
 
 [Installation guide][13]. At this point, you should have already:
-- installed the mutating admission webhook
+- enabled workload identity and OIDC issuer. (az aks update -g "${RESOURCE_GROUP}" -n myAKSCluster --enable-oidc-issuer --enable-workload-identity)
+- installed the mutating admission webhook. (mutating admission webhook installation is not required if workload identity is enabled on the cluster level, using the --enable-workload-identity flag)
 - obtained your cluster's OIDC issuer URL
 - [optional] installed the Azure AD Workload Identity CLI
 


### PR DESCRIPTION
…-identity flag

https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster#update-an-existing-aks-cluster

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
If an user enabled the workload identity on the AKS Cluster, there is no need of manual installation of mutating admission webhook, By enabling workload identity on the AKS Cluster it installs the mutating admission webhook components in the kube-system namespace by default.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
--> No

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
--> No

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] no

**Notes for Reviewers**:
