### PR TITLE
ci: set check-latest flag to true in gh workflows

### DIFF
--- a/.github/workflows/azwi-build.yaml
+++ b/.github/workflows/azwi-build.yaml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: "1.21"
+          check-latest: true
       - name: Build azwi
         run: |
           make bin/azwi

--- a/.github/workflows/azwi-e2e.yaml
+++ b/.github/workflows/azwi-e2e.yaml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: "1.21"
+          check-latest: true
       - name: Azure CLI
         run: |
           echo "Azure CLI Current installed version"
@@ -116,6 +117,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: "1.21"
+          check-latest: true
       - name: Build azwi
         run: |
           make bin/azwi

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: "^1.21"
+          check-latest: true
       - name: Run tests
         run: make test
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d

--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: "1.21"
+          check-latest: true
       - run: make release-manifest
         env:
           NEW_VERSION: "${{ github.event.inputs.release_version }}"

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: "1.21"
+          check-latest: true
       - id: get-tag
         name: Get tag
         run: echo "tag=$(echo ${{ github.event.pull_request.head.ref }} | sed -e 's/release-//g')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Set `check-latest: true` in gh workflows.

If check-latest is set to true, the action first checks if the cached version is the latest one. If the locally cached version is not the most up-to-date, a Go version will then be downloaded. (xref: https://github.com/actions/setup-go?tab=readme-ov-file#check-latest-version).