### PR TITLE
chore: use base images from mcr

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.k8s.io/build-image/distroless-iptables:v0.4.2
+FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.k8s.io/build-image/distroless-iptables:v0.4.3
 
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh

--- a/docker/proxy.Dockerfile
+++ b/docker/proxy.Dockerfile
@@ -1,7 +1,4 @@
-ARG BUILDER=mcr.microsoft.com/oss/go/microsoft/golang:1.21-bullseye
-ARG BASEIMAGE=gcr.io/distroless/static:nonroot
-
-FROM ${BUILDER} as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21-bookworm as builder
 
 ARG LDFLAGS
 
@@ -21,9 +18,7 @@ COPY pkg/ pkg/
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS:--X github.com/Azure/azure-workload-identity/pkg/version.BuildVersion=latest}" -o proxy main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM --platform=${TARGETPLATFORM:-linux/amd64} ${BASEIMAGE}
+FROM --platform=${TARGETPLATFORM:-linux/amd64} mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0-nonroot
 WORKDIR /
 COPY --from=builder /workspace/proxy .
 # Kubernetes runAsNonRoot requires USER to be numeric

--- a/docker/webhook.Dockerfile
+++ b/docker/webhook.Dockerfile
@@ -1,8 +1,5 @@
-ARG BUILDER=mcr.microsoft.com/oss/go/microsoft/golang:1.21-bullseye
-ARG BASEIMAGE=gcr.io/distroless/static:nonroot
-
 # Build the manager binary
-FROM ${BUILDER} as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21-bookworm as builder
 
 ARG LDFLAGS
 
@@ -22,9 +19,7 @@ COPY pkg/ pkg/
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS:--X github.com/Azure/azure-workload-identity/pkg/version.BuildVersion=latest}" -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM --platform=${TARGETPLATFORM:-linux/amd64} ${BASEIMAGE}
+FROM --platform=${TARGETPLATFORM:-linux/amd64} mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0-nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 # Kubernetes runAsNonRoot requires USER to be numeric

--- a/examples/msal-go/Dockerfile
+++ b/examples/msal-go/Dockerfile
@@ -1,7 +1,4 @@
-ARG BUILDER=mcr.microsoft.com/oss/go/microsoft/golang:1.21-bullseye
-ARG BASEIMAGE=gcr.io/distroless/static:nonroot
-
-FROM ${BUILDER} as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -19,9 +16,7 @@ COPY token_credential.go token_credential.go
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o msalgo .
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM --platform=${TARGETPLATFORM:-linux/amd64} ${BASEIMAGE}
+FROM --platform=${TARGETPLATFORM:-linux/amd64} mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0-nonroot
 WORKDIR /
 COPY --from=builder /workspace/msalgo .
 # Kubernetes runAsNonRoot requires USER to be numeric

--- a/examples/msal-go/windows.Dockerfile
+++ b/examples/msal-go/windows.Dockerfile
@@ -1,8 +1,7 @@
-ARG BUILDER=mcr.microsoft.com/oss/go/microsoft/golang:1.21-bullseye
 ARG SERVERCORE_CACHE=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-${OS_VERSION:-1809}
 ARG BASEIMAGE=mcr.microsoft.com/windows/nanoserver:${OS_VERSION:-1809}
 
-FROM --platform=linux/amd64 ${BUILDER} as builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.21-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/examples/msal-node/Dockerfile
+++ b/examples/msal-node/Dockerfile
@@ -1,8 +1,6 @@
-ARG BUILDER=mcr.microsoft.com/cbl-mariner/base/nodejs:16
 ARG BASEIMAGE=mcr.microsoft.com/mirror/gcr/distroless/nodejs-debian11:16
 
-# ref: https://github.com/GoogleContainerTools/distroless/blob/main/examples/nodejs/Dockerfile
-FROM ${BUILDER} AS build-env
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21-bookworm as build-env
 ADD . /app
 WORKDIR /app
 RUN npm install

--- a/examples/msal-python/Dockerfile
+++ b/examples/msal-python/Dockerfile
@@ -1,8 +1,4 @@
-ARG BUILDER=debian:11-slim
-ARG BASEIMAGE=gcr.io/distroless/python3-debian11
-
-# ref: https://github.com/GoogleContainerTools/distroless/blob/main/examples/python3-requirements/Dockerfile
-FROM ${BUILDER}  AS build
+FROM debian:11-slim  AS build
 RUN apt-get update && \
     apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
     python3 -m venv /venv && \
@@ -14,7 +10,7 @@ COPY requirements.txt /requirements.txt
 RUN /venv/bin/pip install --disable-pip-version-check -r /requirements.txt
 
 # Copy the virtualenv into a distroless image
-FROM ${BASEIMAGE}
+FROM mcr.microsoft.com/cbl-mariner/distroless/python:3.9
 COPY --from=build-venv /venv /venv
 COPY . /app
 WORKDIR /app

--- a/examples/msal-python/Dockerfile
+++ b/examples/msal-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11-slim  AS build
+FROM mcr.microsoft.com/mirror/docker/library/debian:bookworm-slim AS build
 RUN apt-get update && \
     apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
     python3 -m venv /venv && \


### PR DESCRIPTION
- use base images from mcr
- bump distroless-iptables to `v0.4.3`