### PR TITLE
fix: check the value of the annotation to actually create the sidecar

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -271,11 +272,12 @@ func (m *podMutator) injectProxySidecarContainer(containers []corev1.Container, 
 }
 
 func shouldInjectProxySidecar(pod *corev1.Pod) bool {
+	positiveAnnotationVal := []string{"true", "1", "yes"}
 	if len(pod.Annotations) == 0 {
 		return false
 	}
-	_, ok := pod.Annotations[InjectProxySidecarAnnotation]
-	return ok
+	val, ok := pod.Annotations[InjectProxySidecarAnnotation]
+	return ok && slices.Contains(positiveAnnotationVal, val)
 }
 
 // getSkipContainers gets the list of containers to skip based on the annotation


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

#1210 

Ensures annotation values are respected

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
