### PR TITLE
chore: optimize the Python sample

### DIFF
--- a/examples/msal-python/requirements.txt
+++ b/examples/msal-python/requirements.txt
@@ -1,2 +1,4 @@
 azure-keyvault-secrets==4.7.0
-msal==1.22.0
+# MSAL's acquire_token_for_client() comes with built-in cache since 1.23
+# And it is safe to upgrade to any new versions in 1.x series
+msal>=1.23,<2

--- a/examples/msal-python/token_credential.py
+++ b/examples/msal-python/token_credential.py
@@ -8,16 +8,20 @@ from msal import ConfidentialClientApplication
 class MyClientAssertionCredential(object):
 
     def __init__(self, azure_client_id, azure_tenant_id, azure_authority_host, azure_federated_token_file):
-        # read the projected service account token file
-        f = open(azure_federated_token_file, 'rb')
+        self.azure_federated_token_file = azure_federated_token_file
         # create a confidential client application
         self.app = ConfidentialClientApplication(
             azure_client_id,
             client_credential={
-                'client_assertion': f.read().decode("utf-8")
+                'client_assertion': self.read_federation_token,  # A callable will be lazily called, whenever a new token is needed
             },
             authority="{}{}".format(azure_authority_host, azure_tenant_id)
         )
+
+    def read_federation_token(self):
+        # read the projected service account token file
+        with open(self.azure_federated_token_file, 'rb') as f:
+            return f.read().decode("utf-8")
 
     def get_token(self, *scopes, **kwargs):
         # get the token using the application


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
The previous sample was a proof-of-concept which only worked as a one-off script, and inefficiently. Problems include:

* Even if you rerun the script immediately, a new file I/O and new http I/O would incur.
* If a real app changes the previous sample into a long-lived daemon, the federation assertion would soon become outdated because the sample never reloads the assertion.

After this PR, the sample, if being used as a long-lived daemon, will automatically attempt token search from cache, and automatically reload the assertion when cache misses.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->
No.

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->
No.

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
I do not have an AKS environment to actually run this change. The repo owner shall be able to test that part.