### PR TITLE
release: update manifest and helm charts for v1.2.1 (part 2)

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -38,6 +38,6 @@ jobs:
         uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
         with:
           version: latest
-          args: release --rm-dist --timeout 150m --debug
+          args: release --clean --timeout 150m --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`--rm-dist` is deprecated, using `--clean` instead.