### PR TITLE
ci: bump ossf/scorecard-action to v2.3.1

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031 # v2.2.0
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Updating `ossf/scorecard-action` to latest (v2.3.1) to resolves [failures](https://github.com/Azure/azure-workload-identity/actions/runs/8558471176/job/23453097806).

xref: https://github.com/ossf/scorecard-action/issues/997