### PR TITLE
chore: update to go 1.22

### DIFF
--- a/.github/workflows/azwi-build.yaml
+++ b/.github/workflows/azwi-build.yaml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - name: Build azwi
         run: |

--- a/.github/workflows/azwi-e2e.yaml
+++ b/.github/workflows/azwi-e2e.yaml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - name: Azure CLI
         run: |
@@ -116,7 +116,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - name: Build azwi
         run: |

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "^1.21"
+          go-version: "^1.22"
           check-latest: true
       - name: Run tests
         run: make test

--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -34,7 +34,7 @@ jobs:
           ref: "${{ github.event.inputs.based_on_branch }}"
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - run: make release-manifest
         env:

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - id: get-tag
         name: Get tag

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   deadline: 20m
-  go-version: "1.21"
+  go-version: "1.22"
 
 linters:
   disable-all: true

--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.k8s.io/build-image/distroless-iptables:v0.5.1
+FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.k8s.io/build-image/distroless-iptables:v0.5.2
 
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh

--- a/docker/proxy.Dockerfile
+++ b/docker/proxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21-bookworm as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22-bookworm as builder
 
 ARG LDFLAGS
 

--- a/docker/webhook.Dockerfile
+++ b/docker/webhook.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21-bookworm as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22-bookworm as builder
 
 ARG LDFLAGS
 

--- a/examples/msal-go/Dockerfile
+++ b/examples/msal-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.21-bookworm as builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/examples/msal-go/windows.Dockerfile
+++ b/examples/msal-go/windows.Dockerfile
@@ -1,7 +1,7 @@
 ARG SERVERCORE_CACHE=gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-${OS_VERSION:-1809}
 ARG BASEIMAGE=mcr.microsoft.com/windows/nanoserver:${OS_VERSION:-1809}
 
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.21-bookworm as builder
+FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.22-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-workload-identity
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Azure/aad-pod-identity v1.8.17

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/azure-workload-identity/test/e2e
 
-go 1.21
+go 1.22
 
 replace (
 	k8s.io/api => k8s.io/api v0.26.3


### PR DESCRIPTION
- update to go 1.22
- update distroless-iptables image to v0.5.2