### PR TITLE
fix: Filter patches to drop `"remove"` operation to prevent dropping unknown fields

### DIFF
--- a/.pipelines/templates/scan-images.yaml
+++ b/.pipelines/templates/scan-images.yaml
@@ -11,7 +11,8 @@ steps:
       tar zxvf trivy_${TRIVY_VERSION:-0.24.4}_Linux-64bit.tar.gz
       # show all vulnerabilities in the logs
       ./trivy image --reset
-      for IMAGE_NAME in "proxy" "proxy-init" "webhook"; do
+      # TODO(aramase): add proxy-init image after https://github.com/kubernetes/release/issues/3593 is fixed
+      for IMAGE_NAME in "proxy" "webhook"; do
         ./trivy image "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-linux-amd64"
         ./trivy image --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-linux-amd64" || exit 1
       done

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	golang.org/x/term v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	golang.org/x/term v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.2.0
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -802,8 +802,8 @@ func TestHandle(t *testing.T) {
 				t.Fatalf("expected to be allowed")
 			}
 			for _, patch := range resp.Patches {
-				if patch.Operation != "add" {
-					t.Errorf("expected add operation, got: %v", patch)
+				if patch.Operation == "remove" && patch.Path != "/metadata/creationTimestamp" {
+					t.Errorf("unexpected patch: %v", patch)
 				}
 			}
 		})

--- a/scripts/create-aks-cluster.sh
+++ b/scripts/create-aks-cluster.sh
@@ -25,8 +25,6 @@ main() {
   if [[ "$(should_create_aks_cluster)" == "true" ]]; then
     echo "Creating an AKS cluster '${CLUSTER_NAME}'"
     LOCATION="$(get_random_region)"
-    # pin to the minor version and aks will pick the latest patch version
-    KUBERNETES_VERSION="1.26"
     az group create --name "${CLUSTER_NAME}" --location "${LOCATION}" > /dev/null
     # TODO(chewong): ability to create an arc-enabled cluster
     az aks create \
@@ -35,7 +33,6 @@ main() {
       --node-vm-size Standard_DS3_v2 \
       --enable-managed-identity \
       --network-plugin azure \
-      --kubernetes-version "${KUBERNETES_VERSION}" \
       --node-count 3 \
       --generate-ssh-keys \
       --enable-oidc-issuer > /dev/null
@@ -44,7 +41,7 @@ main() {
         EXTRA_ARGS="--aks-custom-headers WindowsContainerRuntime=containerd"
       fi
       # shellcheck disable=SC2086
-      az aks nodepool add --resource-group "${CLUSTER_NAME}" --cluster-name "${CLUSTER_NAME}" --os-type Windows --name npwin --kubernetes-version "${KUBERNETES_VERSION}" --node-count 3 ${EXTRA_ARGS:-} > /dev/null
+      az aks nodepool add --resource-group "${CLUSTER_NAME}" --cluster-name "${CLUSTER_NAME}" --os-type Windows --name npwin --node-count 3 ${EXTRA_ARGS:-} > /dev/null
     fi
   fi
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
Filter patches to only allow "add" operation to prevent dropping unknown fields

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/azure-workload-identity/issues/1312
