### PR TITLE
ci: remove pinned k8s version for aks clusters

### DIFF
--- a/.pipelines/templates/scan-images.yaml
+++ b/.pipelines/templates/scan-images.yaml
@@ -11,7 +11,8 @@ steps:
       tar zxvf trivy_${TRIVY_VERSION:-0.24.4}_Linux-64bit.tar.gz
       # show all vulnerabilities in the logs
       ./trivy image --reset
-      for IMAGE_NAME in "proxy" "proxy-init" "webhook"; do
+      # TODO(aramase): add proxy-init image after https://github.com/kubernetes/release/issues/3593 is fixed
+      for IMAGE_NAME in "proxy" "webhook"; do
         ./trivy image "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-linux-amd64"
         ./trivy image --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/${IMAGE_NAME}:${IMAGE_VERSION}-linux-amd64" || exit 1
       done

--- a/scripts/create-aks-cluster.sh
+++ b/scripts/create-aks-cluster.sh
@@ -25,8 +25,6 @@ main() {
   if [[ "$(should_create_aks_cluster)" == "true" ]]; then
     echo "Creating an AKS cluster '${CLUSTER_NAME}'"
     LOCATION="$(get_random_region)"
-    # pin to the minor version and aks will pick the latest patch version
-    KUBERNETES_VERSION="1.26"
     az group create --name "${CLUSTER_NAME}" --location "${LOCATION}" > /dev/null
     # TODO(chewong): ability to create an arc-enabled cluster
     az aks create \
@@ -35,7 +33,6 @@ main() {
       --node-vm-size Standard_DS3_v2 \
       --enable-managed-identity \
       --network-plugin azure \
-      --kubernetes-version "${KUBERNETES_VERSION}" \
       --node-count 3 \
       --generate-ssh-keys \
       --enable-oidc-issuer > /dev/null
@@ -44,7 +41,7 @@ main() {
         EXTRA_ARGS="--aks-custom-headers WindowsContainerRuntime=containerd"
       fi
       # shellcheck disable=SC2086
-      az aks nodepool add --resource-group "${CLUSTER_NAME}" --cluster-name "${CLUSTER_NAME}" --os-type Windows --name npwin --kubernetes-version "${KUBERNETES_VERSION}" --node-count 3 ${EXTRA_ARGS:-} > /dev/null
+      az aks nodepool add --resource-group "${CLUSTER_NAME}" --cluster-name "${CLUSTER_NAME}" --os-type Windows --name npwin --node-count 3 ${EXTRA_ARGS:-} > /dev/null
     fi
   fi
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
Remove pinned k8s version for aks clusters in CI.

This will resolve cluster creation failure in CI: https://dev.azure.com/AzureContainerUpstream/Azure%20Workload%20Identity/_build/results?buildId=162979&view=logs&jobId=377f0d06-9179-5249-f9a7-28bb5766ad7b&j=b3c1b3ef-28d7-5409-0106-cc1f1619b84c&t=9e7e4005-272c-58b2-628a-739ad1a735d9