### PR TITLE
ci: cleanup windows pr gate

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -79,11 +79,7 @@ jobs:
         value: "true"
     strategy:
       matrix:
-        soak_aks_windows_dockershim:
-          WINDOWS_CLUSTER: "true"
-          GINKGO_SKIP: \[LinuxOnly\]
-          CLUSTER_NAME: "azwi-aks-win-dockershim"
-        soak_aks_windows_containerd:
+        soak_aks_windows:
           WINDOWS_CLUSTER: "true"
           GINKGO_SKIP: \[LinuxOnly\]
           CLUSTER_NAME: "azwi-aks-win-containerd"
@@ -104,12 +100,8 @@ jobs:
         - scan_images
         - verify_deployment_yaml
       matrix:
-        upgrade_aks_windows_dockershim:
+        upgrade_aks_windows:
           WINDOWS_CLUSTER: "true"
-          GINKGO_SKIP: \[AKSSoakOnly\]
-        upgrade_aks_windows_containerd:
-          WINDOWS_CLUSTER: "true"
-          WINDOWS_CONTAINERD: "true"
           GINKGO_SKIP: \[AKSSoakOnly\]
         upgrade_aks_linux:
           GINKGO_SKIP: \[AKSSoakOnly\]

--- a/.pipelines/pr.yaml
+++ b/.pipelines/pr.yaml
@@ -80,14 +80,9 @@ jobs:
       - group: e2e-environment-variables
     strategy:
       matrix:
-        aks_windows_dockershim:
+        aks_windows:
           REGISTRY: upstream.azurecr.io/azure-workload-identity
           WINDOWS_CLUSTER: "true"
-          GINKGO_SKIP: \[AKSSoakOnly\]
-        aks_windows_containerd:
-          REGISTRY: upstream.azurecr.io/azure-workload-identity
-          WINDOWS_CLUSTER: "true"
-          WINDOWS_CONTAINERD: "true"
           GINKGO_SKIP: \[AKSSoakOnly\]
         aks_linux:
           REGISTRY: upstream.azurecr.io/azure-workload-identity

--- a/scripts/create-aks-cluster.sh
+++ b/scripts/create-aks-cluster.sh
@@ -37,9 +37,6 @@ main() {
       --generate-ssh-keys \
       --enable-oidc-issuer > /dev/null
     if [[ "${WINDOWS_CLUSTER:-}" == "true" ]]; then
-      if [[ "${WINDOWS_CONTAINERD:-}" == "true" ]]; then
-        EXTRA_ARGS="--aks-custom-headers WindowsContainerRuntime=containerd"
-      fi
       # shellcheck disable=SC2086
       az aks nodepool add --resource-group "${CLUSTER_NAME}" --cluster-name "${CLUSTER_NAME}" --os-type Windows --name npwin --node-count 3 ${EXTRA_ARGS:-} > /dev/null
     fi


### PR DESCRIPTION
- The default container runtime is `containerd` in windows, so the `windows_containerd` job is a duplicate with steps that weren't required.