### PR TITLE
Extend helm chart to create secret token and include automount toggle…

### DIFF
--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-admin-serviceaccount copy.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-admin-serviceaccount copy.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- toYaml .Values.imagePullSecrets | nindent 2 }}
+{{- end }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+metadata:
+  labels:
+    app: '{{ template "workload-identity-webhook.name" . }}'
+    azure-workload-identity.io/system: "true"
+    chart: '{{ template "workload-identity-webhook.name" . }}'
+    release: '{{ .Release.Name }}'
+  name: azure-wi-webhook-admin
+  namespace: '{{ .Release.Namespace }}'

--- a/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-server-sa-secret.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/templates/azure-wi-webhook-server-sa-secret.yaml
@@ -1,0 +1,15 @@
+{{- if semverCompare "<1.24.0" .Capabilities.KubeVersion.Version -}} 
+# Create the service account token secret for the service account if Kubernetes version is older than 1.24
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: '{{ template "workload-identity-webhook.name" . }}'
+    azure-workload-identity.io/system: "true"
+    chart: '{{ template "workload-identity-webhook.name" . }}'
+    release: '{{ .Release.Name }}'
+  name: azure-wi-webhook-admin-token
+  annotations:
+    kubernetes.io/service-account.name: azure-wi-webhook-admin
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/manifest_staging/charts/workload-identity-webhook/values copy.yaml
+++ b/manifest_staging/charts/workload-identity-webhook/values copy.yaml
@@ -1,0 +1,43 @@
+# Default values for workload-identity-webhook.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+image:
+  repository: mcr.microsoft.com/oss/azure/workload-identity/webhook
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  release: v1.3.0
+imagePullSecrets: []
+# Define if the service account can be used by default (automount property)
+serviceAccount:
+  automountServiceAccountToken: false
+nodeSelector:
+  kubernetes.io/os: linux
+resources:
+  limits:
+    cpu: 100m
+    memory: 30Mi
+  requests:
+    cpu: 100m
+    memory: 20Mi
+tolerations: []
+affinity: {}
+service:
+  type: ClusterIP
+  port: 443
+  targetPort: 9443
+azureEnvironment: AzurePublicCloud
+azureTenantID:
+logLevel: info
+metricsAddr: ":8095"
+metricsBackend: prometheus
+priorityClassName: system-cluster-critical
+mutatingWebhookAnnotations: {}
+podLabels: {}
+podAnnotations: {}
+mutatingWebhookNamespaceSelector: {}
+# minAvailable and maxUnavailable are mutually exclusive
+podDisruptionBudget:
+  minAvailable: 1
+  # maxUnavailable: 0


### PR DESCRIPTION
… for service account

**Reason for Change**:

- Depending of the security controls in place on the cluster, service accounts may have the `automountServiceAccountToken` property set to `false`
- Starting on Kubernetes 1.24, the automatic creation of Secrets of type kubernetes.io/service-account-token was disabled by default. This change introduces this secret to be deployed with the chart in order to it work

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [X] squashed commits
- [X] included documentation
- [X] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [X] no

**Notes for Reviewers**:

- In current state, when deploying the current chart to a cluster with policies to prevent service account automount, it fails.