### PR TITLE
fix: update authority url in confidential client

### DIFF
--- a/examples/msal-go/token_credential.go
+++ b/examples/msal-go/token_credential.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"time"
 
@@ -37,7 +38,12 @@ func newClientAssertionCredential(tenantID, clientID, authorityHost, file string
 		},
 	)
 
-	client, err := confidential.New(fmt.Sprintf("%s%s/oauth2/token", authorityHost, tenantID), clientID, cred)
+	authority, err := url.JoinPath(authorityHost, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct authority URL: %w", err)
+	}
+
+	client, err := confidential.New(authority, clientID, cred)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create confidential client: %w", err)
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -197,8 +198,12 @@ func doTokenRequest(ctx context.Context, clientID, resource, tenantID, authority
 	cred := confidential.NewCredFromAssertionCallback(func(context.Context, confidential.AssertionRequestOptions) (string, error) {
 		return readJWTFromFS(tokenFilePath)
 	})
+	authority, err := url.JoinPath(authorityHost, tenantID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to construct authority URL")
+	}
 
-	confidentialClientApp, err := confidential.New(fmt.Sprintf("%s%s/oauth2/token", authorityHost, tenantID), clientID, cred)
+	confidentialClientApp, err := confidential.New(authority, clientID, cred)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create confidential client app")
 	}


### PR DESCRIPTION
According to the function signature
```go
// New is the constructor for Client. authority is the URL of a token authority such as "https://login.microsoftonline.com/<your tenant>".
// If the Client will connect directly to AD FS, use "adfs" for the tenant. clientID is the application's client ID (also called its
// "application ID").
func New(authority, clientID string, cred Credential, options ...Option) (Client, error) {
```

xref: https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/v1.2.2/apps/confidential/confidential.go#L310-L313
