### PR TITLE
feat: allow proxies to be injected using a native sidecar

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -168,7 +168,7 @@ func setupWebhook(mgr manager.Manager, setupFinished chan struct{}) {
 
 	// setup webhooks
 	entryLog.Info("registering webhook to the webhook server")
-	podMutator, err := wh.NewPodMutator(mgr.GetClient(), mgr.GetAPIReader(), audience, mgr.GetScheme())
+	podMutator, err := wh.NewPodMutator(mgr.GetClient(), mgr.GetAPIReader(), audience, mgr.GetScheme(), mgr.GetConfig())
 	if err != nil {
 		panic(fmt.Errorf("unable to set up pod mutator: %w", err))
 	}

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -59,6 +59,8 @@ var _ = ginkgo.Describe("Proxy [LinuxOnly] [AKSSoakOnly]", func() {
 			}
 		}()
 
+		validateProxySideCarInMutatedPod(pod)
+
 		for _, container := range []string{busybox1, busybox2} {
 			framework.Logf("validating that %s in %s has acquired a valid AAD token via the proxy", container, pod.Name)
 			gomega.Eventually(func() bool {
@@ -112,6 +114,8 @@ var _ = ginkgo.Describe("Proxy [LinuxOnly] [AKSSoakOnly]", func() {
 				framework.Logf("%s logs: %s", container, stdout)
 			}
 		}()
+
+		validateProxySideCarInMutatedPod(pod)
 
 		for _, container := range []string{busybox1, busybox2} {
 			framework.Logf("validating that %s in %s has acquired a valid AAD token via the proxy using AZURE_CLIENT_ID", container, pod.Name)


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

Fixes [Issue 773](https://github.com/Azure/azure-workload-identity/issues/773) by using [native sidecars](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/) so that pods exit cleanly when running as cronjobs, currently azwi sidecar prevents the pod from terminating. 

It also addresses an annoyance where the first container in the pod is the proxy, so any `kubectl` commands target that container, previously I was working around this by adding the [default-container](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container) annotation.

When running on kubernetes >=1.28 it will use native sidecars, otherwise it will use the original approach.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->
No update to deployment.yaml

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->
No change to Helm chart

**Requirements**

- [X] squashed commits
- [X] included documentation
- [X] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #733

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [X] no

**Notes for Reviewers**:
Tested on v1.30.0-eks-fff26e3