### PR TITLE
feat: Update existing SDK environment variables

### DIFF
--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -527,7 +527,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "existing environment variables not replaced",
+			name: "existing environment variables should be replaced to support admission reinvocation",
 			container: corev1.Container{
 				Name:  "cont1",
 				Image: "image",
@@ -542,11 +542,11 @@ func TestAddEnvironmentVariables(t *testing.T) {
 					},
 					{
 						Name:  AzureFederatedTokenFileEnvVar,
-						Value: filepath.Join(TokenFileMountPath, TokenFilePathName),
+						Value: "/tmp/token",
 					},
 					{
 						Name:  AzureAuthorityHostEnvVar,
-						Value: "https://login.microsoftonline.com/",
+						Value: "https://localhost:8080/",
 					},
 				},
 			},
@@ -556,11 +556,11 @@ func TestAddEnvironmentVariables(t *testing.T) {
 				Env: []corev1.EnvVar{
 					{
 						Name:  AzureClientIDEnvVar,
-						Value: "myClientID",
+						Value: "clientID",
 					},
 					{
 						Name:  AzureTenantIDEnvVar,
-						Value: "myTenantID",
+						Value: "tenantID",
 					},
 					{
 						Name:  AzureFederatedTokenFileEnvVar,
@@ -616,7 +616,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualContainer := addEnvironmentVariables(test.container, "clientID", "tenantID", "https://login.microsoftonline.com/")
+			actualContainer := setEnvironmentVariables(test.container, "clientID", "tenantID", "https://login.microsoftonline.com/")
 			if !reflect.DeepEqual(actualContainer, test.expectedContainer) {
 				t.Fatalf("expected: %v, got: %v", test.expectedContainer, actualContainer)
 			}


### PR DESCRIPTION
This enables processing of already admitted and modified containers. This might occur since the `reinvocationPolicy` has been set to `IfNeeded` #749.

**Reason for Change**:
Not updating existing environment variables might result in a situation where the wrong credentials are projected into the container, whenever another admission plugin modifies the `serviceAccountName`.

**Requirements**

- [X] squashed commits
- [ ] included documentation
- [X] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
Fixes #1475 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? 
- [X] no

If so, did you notify the maintainers and provide attribution?
not relevant