### PR TITLE
chore: update distroless-iptables to v0.6.5

### DIFF
--- a/docker/proxy-init.Dockerfile
+++ b/docker/proxy-init.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.k8s.io/build-image/distroless-iptables:v0.6.3
+FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.k8s.io/build-image/distroless-iptables:v0.6.5
 
 COPY ./init/init-iptables.sh /bin/
 RUN chmod +x /bin/init-iptables.sh


### PR DESCRIPTION
update distroless-iptables to `v0.6.5`