### PR TITLE
ci: update goreleaser config for v2

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Goreleaser
         uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
         with:
-          version: latest
-          args: release --clean --timeout 150m --debug
+          version: "~> v2"
+          args: release --clean --fail-fast --timeout 150m --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 # refer to https://goreleaser.com for more options
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -42,7 +43,7 @@ checksum:
   name_template: 'sha256sums.txt'
   algorithm: sha256
 changelog:
-  skip: false
+  disable: false
   groups:
     - title: Bug Fixes 🐞
       regexp: ^.*fix[(\\w)]*:+.*$


### PR DESCRIPTION
```shell
azure-workload-identity on  aramase/ci/goreleaser_v2 [$] 
➜ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```