### PR TITLE
ci: cleanup disk in release workflow to avoid running out of space

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -9,8 +9,18 @@ permissions:
 
 jobs:
   create-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
+      - name: Cleanup disk
+        run: |
+          # Cleaning up unused tools based on the suggested workaround:
+          # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+
+          # Partial cleanup from the suggested workaround.
+          # If we continue running out of space, we can remove everything listed in the workaround.
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Harden Runner
         uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
         with:


### PR DESCRIPTION
`create_release` workflow is failing because of
```bash
  ⨯ release failed after 12m10s             
    error=
    │ build failed: exit status 1: # github.com/microsoftgraph/msgraph-sdk-go/users
    │ compile: writing output: write $WORK/b937/_pkg_.a: no space left on device
    target=darwin_amd64_v1
```
ref: https://github.com/Azure/azure-workload-identity/actions/runs/14386886310/job/40344393067