### PR TITLE
fix(webhook): do not add environment variables when they are empty

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -394,9 +394,9 @@ func addEnvironmentVariables(container corev1.Container, clientID, tenantID, azu
 		{Name: AzureAuthorityHostEnvVar, Value: azureAuthorityHost},
 	}
 
-	// append only the ones not already present
+	// append the ones that are not already present (only if desired env contains a non-empty value)
 	for _, env := range desiredEnvs {
-		if _, ok := m[env.Name]; !ok {
+		if _, ok := m[env.Name]; !ok && env.Value != "" {
 			container.Env = append(container.Env, env)
 		}
 	}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -627,6 +627,29 @@ func TestAddEnvironmentVariables(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("environment variables are not added when empty", func(t *testing.T) {
+		container := corev1.Container{
+			Name:  "cont1",
+			Image: "image",
+		}
+
+		expectedContainer := corev1.Container{
+			Name:  "cont1",
+			Image: "image",
+			Env: []corev1.EnvVar{
+				{
+					Name:  AzureFederatedTokenFileEnvVar,
+					Value: filepath.Join(TokenFileMountPath, TokenFilePathName),
+				},
+			},
+		}
+
+		actualContainer := addEnvironmentVariables(container, "", "", "")
+		if !reflect.DeepEqual(actualContainer, expectedContainer) {
+			t.Fatalf("expected: %v, got: %v", expectedContainer, actualContainer)
+		}
+	})
 }
 
 func TestAddProjectServiceAccountTokenVolumeMount(t *testing.T) {


### PR DESCRIPTION
**Reason for Change**:

As explained in more details in #1555, results of webhook mutation would be better if empty environment variables are not added to container spec. - `Env` section of a pod spec (used by the webhook) has higher precedence than `envFrom`, so if the environment variables are imported using the latter, container still starts with empty values populated by the webhook.

**Requirements**

- [X] squashed commits
- [ ] included documentation (not applicable)
- [X] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
Fixes: #1555

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [X] no

**Notes for Reviewers**:
At first, I proposed to make the change only for `AZURE_CLIENT_ID`, @aramase agreed to that in the related issue: https://github.com/Azure/azure-workload-identity/issues/1555#issuecomment-2756202558, but I think it would also make sense to have the same behaviour for `AZURE_TENANT_ID` and `AZURE_AUTHORITY_HOST` even though I personally care only about contents of `AZURE_CLIENT_ID`.