### PR TITLE
test: cleanup use of wi labels in service account for e2e

### DIFF
--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -24,12 +24,11 @@ const (
 )
 
 // createServiceAccount creates a service account with customizable name, namespace, labels and annotations.
-func createServiceAccount(c kubernetes.Interface, namespace, name string, labels, annotations map[string]string) string {
+func createServiceAccount(c kubernetes.Interface, namespace, name string, annotations map[string]string) string {
 	account := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
-			Labels:      labels,
 			Annotations: annotations,
 		},
 	}

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -26,7 +26,7 @@ var _ = ginkgo.Describe("Proxy [LinuxOnly] [AKSSoakOnly]", func() {
 		gomega.Expect(ok).To(gomega.BeTrue(), "APPLICATION_CLIENT_ID must be set")
 		// trust is only set up for 'proxy-test-sa' service account in the default namespace for now
 		const namespace = "default"
-		serviceAccount := createServiceAccount(f.ClientSet, namespace, "proxy-test-sa", map[string]string{useWorkloadIdentityLabel: "true"}, map[string]string{clientIDAnnotation: clientID})
+		serviceAccount := createServiceAccount(f.ClientSet, namespace, "proxy-test-sa", map[string]string{clientIDAnnotation: clientID})
 		defer f.ClientSet.CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), serviceAccount, metav1.DeleteOptions{})
 
 		proxyAnnotations := map[string]string{
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("Proxy [LinuxOnly] [AKSSoakOnly]", func() {
 		gomega.Expect(ok).To(gomega.BeTrue(), "APPLICATION_CLIENT_ID must be set")
 		// trust is only set up for 'proxy-test-sa' service account in the default namespace for now
 		const namespace = "default"
-		serviceAccount := createServiceAccount(f.ClientSet, namespace, "proxy-test-sa", map[string]string{useWorkloadIdentityLabel: "true"}, map[string]string{clientIDAnnotation: clientID})
+		serviceAccount := createServiceAccount(f.ClientSet, namespace, "proxy-test-sa", map[string]string{clientIDAnnotation: clientID})
 		defer f.ClientSet.CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), serviceAccount, metav1.DeleteOptions{})
 
 		proxyAnnotations := map[string]string{

--- a/test/e2e/token_exchange.go
+++ b/test/e2e/token_exchange.go
@@ -32,7 +32,7 @@ var _ = ginkgo.Describe("TokenExchange [AKSSoakOnly]", func() {
 
 		// trust is only set up for 'pod-identity-sa' service account in the default namespace for now
 		const namespace = "default"
-		serviceAccount := createServiceAccount(f.ClientSet, namespace, "pod-identity-sa", map[string]string{useWorkloadIdentityLabel: "true"}, map[string]string{clientIDAnnotation: clientID})
+		serviceAccount := createServiceAccount(f.ClientSet, namespace, "pod-identity-sa", map[string]string{clientIDAnnotation: clientID})
 		defer f.ClientSet.CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), serviceAccount, metav1.DeleteOptions{})
 
 		pod, err := createPodWithServiceAccount(

--- a/test/e2e/webhook.go
+++ b/test/e2e/webhook.go
@@ -31,7 +31,7 @@ var _ = ginkgo.Describe("Webhook", func() {
 	f := framework.NewDefaultFramework("webhook")
 
 	ginkgo.It("should mutate a labeled pod", func(ctx context.Context) {
-		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", nil, nil)
+		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{clientIDAnnotation: "000-0000-0000-0000"})
 		pod, err := createPodWithServiceAccount(
 			f.ClientSet,
 			f.Namespace.Name,
@@ -49,7 +49,7 @@ var _ = ginkgo.Describe("Webhook", func() {
 	})
 
 	ginkgo.It("should mutate the init containers within a pod", func(ctx context.Context) {
-		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{useWorkloadIdentityLabel: "true"}, nil)
+		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{clientIDAnnotation: "000-0000-0000-0000"})
 
 		pod := generatePodWithServiceAccount(
 			f.ClientSet,
@@ -89,20 +89,20 @@ var _ = ginkgo.Describe("Webhook", func() {
 	})
 
 	ginkgo.It("should mutate a deployment pod with a labeled pod spec", func(ctx context.Context) {
-		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{useWorkloadIdentityLabel: "true"}, nil)
+		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{clientIDAnnotation: "000-0000-0000-0000"})
 		pod := createPodUsingDeploymentWithServiceAccount(ctx, f, serviceAccount)
 		validateMutatedPod(ctx, f, pod, nil)
 	})
 
 	ginkgo.It("should mutate a deployment pod with an annotated service account", func(ctx context.Context) {
-		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", nil, map[string]string{useWorkloadIdentityLabel: "true"})
+		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{clientIDAnnotation: "000-0000-0000-0000"})
 		pod := createPodUsingDeploymentWithServiceAccount(ctx, f, serviceAccount)
 		validateMutatedPod(ctx, f, pod, nil)
 	})
 
 	ginkgo.It(fmt.Sprintf("should not mutate selected containers if the pod has %s annotated", skipContainersAnnotation), func(ctx context.Context) {
 		const skipContainers = busybox1 + ";"
-		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{useWorkloadIdentityLabel: "true"}, nil)
+		serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{clientIDAnnotation: "000-0000-0000-0000"})
 		pod, err := createPodWithServiceAccount(
 			f.ClientSet,
 			f.Namespace.Name,
@@ -125,7 +125,7 @@ var _ = ginkgo.Describe("Webhook", func() {
 		{serviceAccountTokenExpiryAnnotation: "invalid"}, // non-numeric value
 	} {
 		ginkgo.It(fmt.Sprintf("should not mutate a pod if '%s: \"%s\"' is annotated to the service account", serviceAccountTokenExpiryAnnotation, annotations[serviceAccountTokenExpiryAnnotation]), func() {
-			serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{useWorkloadIdentityLabel: "true"}, annotations)
+			serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", annotations)
 			_, err := createPodWithServiceAccount(
 				f.ClientSet,
 				f.Namespace.Name,
@@ -143,7 +143,7 @@ var _ = ginkgo.Describe("Webhook", func() {
 		})
 
 		ginkgo.It(fmt.Sprintf("should not mutate a pod if '%s: \"%s\"' is annotated to the pod", serviceAccountTokenExpiryAnnotation, annotations[serviceAccountTokenExpiryAnnotation]), func() {
-			serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", map[string]string{useWorkloadIdentityLabel: "true"}, nil)
+			serviceAccount := createServiceAccount(f.ClientSet, f.Namespace.Name, f.Namespace.Name+"-sa", nil)
 			_, err := createPodWithServiceAccount(
 				f.ClientSet,
 				f.Namespace.Name,


### PR DESCRIPTION
We don't need any label on the Kubernetes service account (this was the old behavior), so cleaning up those labels in e2e.