### PR TITLE
ci: skip key download if preflight is true

### DIFF
--- a/scripts/create-kind-cluster.sh
+++ b/scripts/create-kind-cluster.sh
@@ -94,7 +94,7 @@ EOF
 }
 
 download_service_account_keys() {
-  if [[ -z "${SERVICE_ACCOUNT_KEYVAULT_NAME:-}" ]]; then
+  if [[ -z "${SERVICE_ACCOUNT_KEYVAULT_NAME:-}" ]] || [[ "${SKIP_PREFLIGHT:-}" == "true" ]]; then
     return
   fi
   az keyvault secret show --vault-name "${SERVICE_ACCOUNT_KEYVAULT_NAME}" --name sa-pub | jq -r .value | base64 -d > "${SERVICE_ACCOUNT_KEY_FILE}"

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -40,7 +40,7 @@ var _ = ginkgo.Describe("Proxy [LinuxOnly] [AKSSoakOnly]", func() {
 			serviceAccount,
 			"mcr.microsoft.com/azure-cli",
 			nil,
-			[]string{"/bin/sh", "-c", fmt.Sprintf("az login -i -u %s --allow-no-subscriptions --debug; sleep 3600", clientID)},
+			[]string{"/bin/sh", "-c", fmt.Sprintf("az login -i --client-id %s --allow-no-subscriptions --debug; sleep 3600", clientID)},
 			nil,
 			proxyAnnotations,
 			map[string]string{useWorkloadIdentityLabel: "true"},


### PR DESCRIPTION
- When `preflight` is true, we don't check for the keys downloaded from AKV. This additional checks also ensures we don't attempt the download the keys when not required.
- Use `--client-id` for az login in the e2e suite as `--username` is no longer supported
```bash
   File "/usr/lib64/az/lib/python3.12/site-packages/azure/cli/command_modules/profile/custom.py", line 137, in login
      raise CLIError('Passing the managed identity ID with --username is no longer supported. '
  knack.util.CLIError: Passing the managed identity ID with --username is no longer supported. Use --client-id, --object-id or --resource-id instead.
```