### PR TITLE
feat: add fallback for AzureKubernetesTokenProxy

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,9 +17,11 @@ type Config struct {
 	ProxyImage     string `envconfig:"PROXY_IMAGE"`
 	ProxyInitImage string `envconfig:"PROXY_INIT_IMAGE"`
 
-	AzureKubernetesTokenProxy string `envconfig:"AZURE_KUBERNETES_TOKEN_PROXY"`
-	AzureKubernetesSNIName    string `envconfig:"AZURE_KUBERNETES_SNI_NAME"`
-	AzureKubernetesCAData     string `envconfig:"AZURE_KUBERNETES_CA_DATA"`
+	AzureKubernetesTokenProxy            string `envconfig:"AZURE_KUBERNETES_TOKEN_PROXY"`
+	AzureKubernetesTokenEndpointFallback string `envconfig:"AZURE_KUBERNETES_TOKEN_ENDPOINT"` // this should be removed after AKS side deployment has been done
+
+	AzureKubernetesSNIName string `envconfig:"AZURE_KUBERNETES_SNI_NAME"`
+	AzureKubernetesCAData  string `envconfig:"AZURE_KUBERNETES_CA_DATA"`
 	// AzureKubernetesCAConfigMapName is the name of the ConfigMap that contains the CA data
 	// The key in the ConfigMap must be "ca.crt".
 	AzureKubernetesCAConfigMapName    string           `envconfig:"AZURE_KUBERNETES_CA_CONFIGMAP_NAME"`
@@ -32,6 +34,11 @@ func ParseConfig() (*Config, error) {
 	c := new(Config)
 	if err := envconfig.Process("config", c); err != nil {
 		return c, err
+	}
+
+	if c.AzureKubernetesTokenProxy == "" && c.AzureKubernetesTokenEndpointFallback != "" {
+		// for backward compatibility, if AZURE_KUBERNETES_TOKEN_PROXY is not set, use AZURE_KUBERNETES_TOKEN_ENDPOINT if set
+		c.AzureKubernetesTokenProxy = c.AzureKubernetesTokenEndpointFallback
 	}
 
 	// validate parsed config


### PR DESCRIPTION
**Reason for Change**:

Set a default vaue to the token proxy so AKS deployment can use this value immediately.

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
