### PR TITLE
docs: add Azure RBAC role assignment best practice for Azure Key Vault

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -132,7 +132,7 @@ The `Key Vault Secrets User` [built-in role](https://learn.microsoft.com/en-us/a
 
 > **Role description:** Read secret contents including secret portion of a certificate with private key. Only works for key vaults that use the 'Azure role-based access control' permission model.
 
-```sh
+```bash
 export APPLICATION_CLIENT_ID="$(az ad sp list --display-name "${APPLICATION_NAME}" --query '[0].appId' -otsv)"
 export KEYVAULT_RESOURCE_ID="$(az keyvault show --name "${KEYVAULT_NAME}" --query 'id' -otsv)"
 

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -111,26 +111,15 @@ az identity create --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${R
 
 </details>
 
-Set access policy for the AAD application or user-assigned managed identity to access the keyvault secret:
-
-Microsoft [recommends](https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-access-policy) for improved security to use the **Azure Role-Based Access Control (RBAC) permission model** instead of the legacy Key Vault access policy model when managing an Azure Key Vault.
+Set access policy for the AAD application or user-assigned managed identity to access the key vault secret:
 
 If using Azure AD Application:
-
-Key Vault access policy (legacy):
-
-```bash
-export APPLICATION_CLIENT_ID="$(az ad sp list --display-name "${APPLICATION_NAME}" --query '[0].appId' -otsv)"
-az keyvault set-policy --name "${KEYVAULT_NAME}" \
-  --secret-permissions get \
-  --spn "${APPLICATION_CLIENT_ID}"
-```
 
 Azure RBAC (the recommended approach):
 
 The `Key Vault Secrets User` [built-in role](https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide?tabs=azure-cli#azure-built-in-roles-for-key-vault-data-plane-operations) is sufficient and adheres to the principle of least privilege for fetching secret content from an Azure Key Vault with Azure Workload Identity.
 
-> **Role description:** Read secret contents including secret portion of a certificate with private key. Only works for key vaults that use the 'Azure role-based access control' permission model.
+> **Role description:** Read secret contents including secret portion of a certificate with private key. Only works for key vaults that use the Azure role-based access control permission model.
 
 ```bash
 export APPLICATION_CLIENT_ID="$(az ad sp list --display-name "${APPLICATION_NAME}" --query '[0].appId' -otsv)"
@@ -143,16 +132,6 @@ az role assignment create \
 ```
 
 If using user-assigned managed identity:
-
-Key Vault access policy (legacy):
-
-```bash
-export USER_ASSIGNED_IDENTITY_CLIENT_ID="$(az identity show --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --query 'clientId' -otsv)"
-export USER_ASSIGNED_IDENTITY_OBJECT_ID="$(az identity show --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${RESOURCE_GROUP}" --query 'principalId' -otsv)"
-az keyvault set-policy --name "${KEYVAULT_NAME}" \
-  --secret-permissions get \
-  --object-id "${USER_ASSIGNED_IDENTITY_OBJECT_ID}"
-```
 
 Azure RBAC (the recommended approach):
 

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -117,7 +117,7 @@ If using Azure AD Application:
 
 Azure RBAC (the recommended approach):
 
-The `Key Vault Secrets User` [built-in role](https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide?tabs=azure-cli#azure-built-in-roles-for-key-vault-data-plane-operations) is sufficient and adheres to the principle of least privilege for fetching secret content from an Azure Key Vault with Azure Workload Identity.
+The `Key Vault Secrets User` [built-in role](https://learn.microsoft.com/azure/key-vault/general/rbac-guide?tabs=azure-cli#azure-built-in-roles-for-key-vault-data-plane-operations) is sufficient and adheres to the principle of least privilege for fetching secret content from an Azure Key Vault with Azure Workload Identity.
 
 > **Role description:** Read secret contents including secret portion of a certificate with private key. Only works for key vaults that use the Azure role-based access control permission model.
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
Improves documentation and follows Microsoft's recommendation for improved security when managing an Azure Key Vault
<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
Added documentation and code snippets