### PR TITLE
build: run go builder on $BUILDPLATFORM for cross-arch images

### DIFF
--- a/docker/proxy.Dockerfile
+++ b/docker/proxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-bookworm@sha256:e1475da3b0412109e79396c15381dd7fd621198161c8ef426b21ae0ea65db838 as builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-bookworm@sha256:e1475da3b0412109e79396c15381dd7fd621198161c8ef426b21ae0ea65db838 as builder
 
 ARG LDFLAGS
 

--- a/docker/webhook.Dockerfile
+++ b/docker/webhook.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-bookworm@sha256:e1475da3b0412109e79396c15381dd7fd621198161c8ef426b21ae0ea65db838 as builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-bookworm@sha256:e1475da3b0412109e79396c15381dd7fd621198161c8ef426b21ae0ea65db838 as builder
 
 ARG LDFLAGS
 

--- a/examples/msal-go/Dockerfile
+++ b/examples/msal-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-bookworm@sha256:e1475da3b0412109e79396c15381dd7fd621198161c8ef426b21ae0ea65db838 as builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-bookworm@sha256:e1475da3b0412109e79396c15381dd7fd621198161c8ef426b21ae0ea65db838 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
`publish_images` was failing on `linux/arm64` with Go runtime crashes during `go mod download` — Go 1.26 hits emulation gaps in `multiarch/qemu-user-static:5.2.0-2`.

Pin the Go builder stage to `$BUILDPLATFORM` so it runs natively on the amd64 runner and cross-compiles via the existing `GOARCH=${TARGETARCH}`, eliminating QEMU from the Go path.