### PR TITLE
fix: make projected volume injection idempotent on webhook reinvocation after metadata.name mutation

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -231,7 +231,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) (respons
 	// get containers to skip
 	skipContainers := getSkipContainers(pod)
 	podUsingCustomTokenEndpoint := m.isUsingCustomTokenEndpoint(pod)
-	volumeName := buildVolumeName(podName)
+	volumeName := getOrBuildVolumeName(pod, podName)
 
 	pod.Spec.InitContainers = m.mutateContainers(pod.Spec.InitContainers, clientID, tenantID, skipContainers, podUsingCustomTokenEndpoint, volumeName)
 	pod.Spec.Containers = m.mutateContainers(pod.Spec.Containers, clientID, tenantID, skipContainers, podUsingCustomTokenEndpoint, volumeName)
@@ -598,4 +598,20 @@ func buildVolumeName(podName string) string {
 	hash := sha256.Sum256([]byte(podName))
 	truncatedHash := fmt.Sprintf("%x", hash)[:63-len(ProjectedVolumeNamePrefix)] // 63 is the max length for volume names
 	return fmt.Sprintf("%s%s", ProjectedVolumeNamePrefix, truncatedHash)
+}
+
+// getOrBuildVolumeName returns the name of the existing workload identity projected
+// volume if one has already been injected into the pod
+func getOrBuildVolumeName(pod *corev1.Pod, podName string) string {
+	for _, v := range pod.Spec.Volumes {
+		if v.Projected == nil {
+			continue
+		}
+		for _, src := range v.Projected.Sources {
+			if src.ServiceAccountToken != nil && src.ServiceAccountToken.Path == TokenFilePath {
+				return v.Name
+			}
+		}
+	}
+	return buildVolumeName(podName)
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->
There is an active issue in AKS: https://github.com/Azure/azure-workload-identity/issues/1744

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1744 

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:
