### PR TITLE
fix(webhook)!: prevent duplicate token mount path on reinvocation

### DIFF
--- a/docs/book/src/installation.md
+++ b/docs/book/src/installation.md
@@ -19,7 +19,7 @@
 
 | Component                               | Description                                                                                                                                                                                                                  | Guide     |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| Mutating Admission Webhook              | Projects a signed service account token to a well-known path (`/var/run/secrets/azure/tokens/azure-identity-token`) and inject authentication-related environment variables to your pods based on annotated service account. | [Link][5] |
+| Mutating Admission Webhook              | Projects a signed service account token to a well-known path (`/var/run/secrets/azure/wi`) and inject authentication-related environment variables to your pods based on annotated service account. | [Link][5] |
 | Azure AD Workload Identity CLI (`azwi`) | A utility CLI that helps manage Azure AD Workload Identity and automate error-prone operations.                                                                                                                              | [Link][6] |
 
 [1]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli

--- a/docs/book/src/installation/mutating-admission-webhook.md
+++ b/docs/book/src/installation/mutating-admission-webhook.md
@@ -14,13 +14,15 @@ Azure AD Workload Identity uses a [mutating admission webhook][1] to project a s
 | `AZURE_TENANT_ID`            | The tenant ID of the Azure subscription.                                                 |
 | `AZURE_FEDERATED_TOKEN_FILE` | The path of the projected service account token file.                                    |
 
-| Volume                 | Description                           |
-| ---------------------- | ------------------------------------- |
-| `azure-identity-token` | The projected service account volume. |
+| Volume                                    | Description                           |
+| ----------------------------------------- | ------------------------------------- |
+| `azure-workload-identity-reserved-<hash>` | The projected service account volume. |
 
-| Volume mount                                         | Description                                           |
-| ---------------------------------------------------- | ----------------------------------------------------- |
-| `/var/run/secrets/azure/tokens/azure-identity-token` | The path of the projected service account token file. |
+| Volume mount                                                  | Description                                           |
+| ------------------------------------------------------------- | ----------------------------------------------------- |
+| `/var/run/secrets/azure/wi/<hash>/token/azure-identity-token` | The path of the projected service account token file. |
+
+> `<hash>` is a per-pod value derived from the pod's identity, so the volume name and mount path are unique per pod.
 
 </details>
 

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -316,15 +316,17 @@ You can verify the following injected properties in the output:
 
 <br/>
 
-| Volume mount                                         | Description                                           |
-| ---------------------------------------------------- | ----------------------------------------------------- |
-| `/var/run/secrets/azure/tokens/azure-identity-token` | The path of the projected service account token file. |
+| Volume mount                                                    | Description                                           |
+| --------------------------------------------------------------- | ----------------------------------------------------- |
+| `/var/run/secrets/azure/wi/<hash>/token/azure-identity-token`   | The path of the projected service account token file. |
 
 <br/>
 
-| Volume                 | Description                           |
-| ---------------------- | ------------------------------------- |
-| `azure-identity-token` | The projected service account volume. |
+| Volume                                     | Description                           |
+| ------------------------------------------ | ------------------------------------- |
+| `azure-workload-identity-reserved-<hash>`  | The projected service account volume. |
+
+> `<hash>` is a per-pod value derived from the pod's identity, so the volume name and mount path are unique per pod.
 
 ```log
 Name:         quick-start
@@ -358,7 +360,7 @@ Containers:
       AZURE_FEDERATED_TOKEN_FILE: (Injected by the webhook)
     Mounts:
       /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-844ns (ro)
-      /var/run/secrets/azure/tokens from azure-identity-token (ro) (Injected by the webhook)
+      /var/run/secrets/azure/wi/<hash> from azure-workload-identity-reserved-<hash> (ro) (Injected by the webhook)
 Conditions:
   Type              Status
   Initialized       True
@@ -372,7 +374,7 @@ Volumes:
     ConfigMapName:           kube-root-ca.crt
     ConfigMapOptional:       <nil>
     DownwardAPI:             true
-  azure-identity-token: (Injected by the webhook)
+  azure-workload-identity-reserved-<hash>: (Injected by the webhook)
     Type:                    Projected (a volume that contains injected data from multiple sources)
     TokenExpirationSeconds:  3600
 QoS Class:                   BestEffort

--- a/docs/book/src/topics/self-managed-clusters/service-account-key-rotation.md
+++ b/docs/book/src/topics/self-managed-clusters/service-account-key-rotation.md
@@ -161,7 +161,7 @@ EOF
 Output the projected service account token:
 
 ```bash
-kubectl exec dummy-pod -- cat /var/run/secrets/azure/tokens/azure-identity-token
+kubectl exec dummy-pod -- sh -c 'cat "$AZURE_FEDERATED_TOKEN_FILE"'
 ```
 
 Decode your token using [jwt.ms][3]. The `kid` field in the token header should be the same as the `kid` of `azwi jwks --public-keys sa-new.pub | jq -r '.keys[0].kid'`. This means that the service account token is signed by the new private key.

--- a/pkg/webhook/consts.go
+++ b/pkg/webhook/consts.go
@@ -54,7 +54,9 @@ const (
 	// The sha256 hash of the pod name will be appended to this prefix
 	ProjectedVolumeNamePrefix = "azure-workload-identity-reserved-"
 	TokenFilePath             = "token/azure-identity-token"
-	VolumeMountPath           = "/var/run/secrets/azure/wi" // #nosec
+	// ProjectedVolumePathPrefix is the prefix for the projected volume mount path.
+	// The sha256 hash of the pod name is appended to this prefix.
+	ProjectedVolumePathPrefix = "/var/run/secrets/azure/wi" // #nosec
 	// DefaultAudience is the audience added to the service account token audience
 	// This value is to be consistent with other token exchange flows in AAD and has
 	// no impact on the actual token exchange flow.

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -232,9 +232,10 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) (respons
 	skipContainers := getSkipContainers(pod)
 	podUsingCustomTokenEndpoint := m.isUsingCustomTokenEndpoint(pod)
 	volumeName := buildVolumeName(podName)
+	volumeMountPath := buildVolumeMountPath(podName)
 
-	pod.Spec.InitContainers = m.mutateContainers(pod.Spec.InitContainers, clientID, tenantID, skipContainers, podUsingCustomTokenEndpoint, volumeName)
-	pod.Spec.Containers = m.mutateContainers(pod.Spec.Containers, clientID, tenantID, skipContainers, podUsingCustomTokenEndpoint, volumeName)
+	pod.Spec.InitContainers = m.mutateContainers(pod.Spec.InitContainers, clientID, tenantID, skipContainers, podUsingCustomTokenEndpoint, volumeName, volumeMountPath)
+	pod.Spec.Containers = m.mutateContainers(pod.Spec.Containers, clientID, tenantID, skipContainers, podUsingCustomTokenEndpoint, volumeName, volumeMountPath)
 
 	m.addProjectedVolume(pod, serviceAccountTokenExpiration, volumeName, podUsingCustomTokenEndpoint)
 
@@ -248,16 +249,16 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) (respons
 
 // mutateContainers mutates the containers by injecting the projected
 // service account token volume and environment variables
-func (m *podMutator) mutateContainers(containers []corev1.Container, clientID, tenantID string, skipContainers sets.Set[string], podUsingCustomTokenEndpoint bool, volumeName string) []corev1.Container {
+func (m *podMutator) mutateContainers(containers []corev1.Container, clientID, tenantID string, skipContainers sets.Set[string], podUsingCustomTokenEndpoint bool, volumeName, volumeMountPath string) []corev1.Container {
 	for i := range containers {
 		// container is in the skip list
 		if skipContainers.Has(containers[i].Name) {
 			continue
 		}
 		// add environment variables to container if not exists
-		containers[i] = m.addEnvironmentVariables(containers[i], clientID, tenantID, m.azureAuthorityHost, podUsingCustomTokenEndpoint)
+		containers[i] = m.addEnvironmentVariables(containers[i], clientID, tenantID, m.azureAuthorityHost, podUsingCustomTokenEndpoint, volumeMountPath)
 		// add the volume mount if not exists
-		containers[i] = addProjectedVolumeMount(containers[i], volumeName)
+		containers[i] = addProjectedVolumeMount(containers[i], volumeName, volumeMountPath)
 	}
 
 	return containers
@@ -435,7 +436,7 @@ func getTenantID(sa *corev1.ServiceAccount, c *config.Config) string {
 }
 
 // addEnvironmentVariables adds the clientID, tenantID and token file path environment variables needed for SDK
-func (m *podMutator) addEnvironmentVariables(container corev1.Container, clientID, tenantID, azureAuthorityHost string, podUsingCustomTokenEndpoint bool) corev1.Container {
+func (m *podMutator) addEnvironmentVariables(container corev1.Container, clientID, tenantID, azureAuthorityHost string, podUsingCustomTokenEndpoint bool, volumeMountPath string) corev1.Container {
 	envs := make(map[string]string)
 	for _, env := range container.Env {
 		envs[env.Name] = env.Value
@@ -444,14 +445,14 @@ func (m *podMutator) addEnvironmentVariables(container corev1.Container, clientI
 	desiredEnvs := []corev1.EnvVar{
 		{Name: AzureClientIDEnvVar, Value: clientID},
 		{Name: AzureTenantIDEnvVar, Value: tenantID},
-		{Name: AzureFederatedTokenFileEnvVar, Value: filepath.Join(VolumeMountPath, TokenFilePath)},
+		{Name: AzureFederatedTokenFileEnvVar, Value: filepath.Join(volumeMountPath, TokenFilePath)},
 		{Name: AzureAuthorityHostEnvVar, Value: azureAuthorityHost},
 	}
 
 	if podUsingCustomTokenEndpoint {
 		desiredEnvs = append(desiredEnvs, corev1.EnvVar{Name: AzureKubernetesTokenProxyEnvVar, Value: m.config.AzureKubernetesTokenProxy})
 		desiredEnvs = append(desiredEnvs, corev1.EnvVar{Name: AzureKubernetesSNINameEnvVar, Value: m.config.AzureKubernetesSNIName})
-		desiredEnvs = append(desiredEnvs, corev1.EnvVar{Name: AzureKubernetesCAFileEnvVar, Value: filepath.Join(VolumeMountPath, CAFilePath)})
+		desiredEnvs = append(desiredEnvs, corev1.EnvVar{Name: AzureKubernetesCAFileEnvVar, Value: filepath.Join(volumeMountPath, CAFilePath)})
 		desiredEnvs = append(desiredEnvs, corev1.EnvVar{Name: AzureKubernetesCADataEnvVar, Value: m.config.AzureKubernetesCAData})
 	}
 
@@ -465,10 +466,10 @@ func (m *podMutator) addEnvironmentVariables(container corev1.Container, clientI
 	return container
 }
 
-func addProjectedVolumeMount(container corev1.Container, volumeName string) corev1.Container {
+func addProjectedVolumeMount(container corev1.Container, volumeName, volumeMountPath string) corev1.Container {
 	volumeMount := corev1.VolumeMount{
 		Name:      volumeName,
-		MountPath: VolumeMountPath,
+		MountPath: volumeMountPath,
 		ReadOnly:  true,
 	}
 
@@ -594,8 +595,26 @@ func serverVersionGTE(discoveryClient discovery.ServerVersionInterface, v *utilv
 	return sv.AtLeast(v), nil
 }
 
-func buildVolumeName(podName string) string {
+// volumeHash returns a deterministic hash of the pod identity, truncated so the
+// resulting reserved volume name stays within the 63 character limit.
+func volumeHash(podName string) string {
 	hash := sha256.Sum256([]byte(podName))
-	truncatedHash := fmt.Sprintf("%x", hash)[:63-len(ProjectedVolumeNamePrefix)] // 63 is the max length for volume names
-	return fmt.Sprintf("%s%s", ProjectedVolumeNamePrefix, truncatedHash)
+	return fmt.Sprintf("%x", hash)[:63-len(ProjectedVolumeNamePrefix)] // 63 is the max length for volume names
+}
+
+// buildVolumeName returns the deterministic reserved name for the projected
+// service account token volume.
+func buildVolumeName(podName string) string {
+	return ProjectedVolumeNamePrefix + volumeHash(podName)
+}
+
+// buildVolumeMountPath returns the deterministic mount path for the projected
+// service account token volume. The hash suffix ensures that if the pod name
+// changes between webhook (re)invocations (for example, another mutating webhook
+// populates metadata.name before this webhook is reinvoked under
+// reinvocationPolicy: IfNeeded), the mount lands at a unique path rather than
+// colliding with the previously injected mount, which the API server rejects
+// with "spec.containers[*].volumeMounts[*].mountPath: must be unique".
+func buildVolumeMountPath(podName string) string {
+	return filepath.Join(ProjectedVolumePathPrefix, volumeHash(podName))
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -32,7 +32,10 @@ var (
 	decoder                   = atypes.NewDecoder(runtime.NewScheme())
 )
 
-const testVolumeName = "azure-workload-identity-reserved-2eb503ce-4af0-45d3-82b1-d79bdfe63d38"
+const (
+	testVolumeName      = "azure-workload-identity-reserved-2eb503ce-4af0-45d3-82b1-d79bdfe63d38"
+	testVolumeMountPath = "/var/run/secrets/azure/wi/2eb503ce-4af0-45d3-82b1-d79bdfe63d38" // #nosec
+)
 
 func newPod(name, namespace, serviceAccountName string, labels, annotations map[string]string, hostNetwork bool) *corev1.Pod {
 	return &corev1.Pod{
@@ -510,7 +513,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 					},
 					{
 						Name:  "AZURE_FEDERATED_TOKEN_FILE",
-						Value: filepath.Join(VolumeMountPath, TokenFilePath),
+						Value: filepath.Join(testVolumeMountPath, TokenFilePath),
 					},
 					{
 						Name:  "AZURE_AUTHORITY_HOST",
@@ -535,7 +538,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 					},
 					{
 						Name:  AzureFederatedTokenFileEnvVar,
-						Value: filepath.Join(VolumeMountPath, TokenFilePath),
+						Value: filepath.Join(testVolumeMountPath, TokenFilePath),
 					},
 					{
 						Name:  AzureAuthorityHostEnvVar,
@@ -557,7 +560,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 					},
 					{
 						Name:  AzureFederatedTokenFileEnvVar,
-						Value: filepath.Join(VolumeMountPath, TokenFilePath),
+						Value: filepath.Join(testVolumeMountPath, TokenFilePath),
 					},
 					{
 						Name:  AzureAuthorityHostEnvVar,
@@ -596,7 +599,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 					},
 					{
 						Name:  AzureFederatedTokenFileEnvVar,
-						Value: filepath.Join(VolumeMountPath, TokenFilePath),
+						Value: filepath.Join(testVolumeMountPath, TokenFilePath),
 					},
 					{
 						Name:  AzureAuthorityHostEnvVar,
@@ -614,7 +617,7 @@ func TestAddEnvironmentVariables(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualContainer := m.addEnvironmentVariables(test.container, "clientID", "tenantID", "https://login.microsoftonline.com/", false)
+			actualContainer := m.addEnvironmentVariables(test.container, "clientID", "tenantID", "https://login.microsoftonline.com/", false, testVolumeMountPath)
 			if !reflect.DeepEqual(actualContainer, test.expectedContainer) {
 				t.Fatalf("expected: %v, got: %v", test.expectedContainer, actualContainer)
 			}
@@ -633,12 +636,12 @@ func TestAddEnvironmentVariables(t *testing.T) {
 			Env: []corev1.EnvVar{
 				{
 					Name:  AzureFederatedTokenFileEnvVar,
-					Value: filepath.Join(VolumeMountPath, TokenFilePath),
+					Value: filepath.Join(testVolumeMountPath, TokenFilePath),
 				},
 			},
 		}
 
-		actualContainer := m.addEnvironmentVariables(container, "", "", "", false)
+		actualContainer := m.addEnvironmentVariables(container, "", "", "", false, testVolumeMountPath)
 		if !reflect.DeepEqual(actualContainer, expectedContainer) {
 			t.Fatalf("expected: %v, got: %v", expectedContainer, actualContainer)
 		}
@@ -663,7 +666,7 @@ func TestAddProjectServiceAccountTokenVolumeMount(t *testing.T) {
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      testVolumeName,
-						MountPath: VolumeMountPath,
+						MountPath: testVolumeMountPath,
 						ReadOnly:  true,
 					},
 				},
@@ -691,7 +694,7 @@ func TestAddProjectServiceAccountTokenVolumeMount(t *testing.T) {
 					},
 					{
 						Name:      testVolumeName,
-						MountPath: VolumeMountPath,
+						MountPath: testVolumeMountPath,
 						ReadOnly:  true,
 					},
 				},
@@ -701,11 +704,74 @@ func TestAddProjectServiceAccountTokenVolumeMount(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualContainer := addProjectedVolumeMount(test.container, testVolumeName)
+			actualContainer := addProjectedVolumeMount(test.container, testVolumeName, testVolumeMountPath)
 			if !reflect.DeepEqual(actualContainer, test.expectedContainer) {
 				t.Fatalf("expected: %v, got: %v", test.expectedContainer, actualContainer)
 			}
 		})
+	}
+}
+
+func TestBuildVolumeMountPath(t *testing.T) {
+	id := "some-pod (prefix)"
+	// the mount path must live under the well-known base directory
+	if got := buildVolumeMountPath(id); !strings.HasPrefix(got, ProjectedVolumePathPrefix+"/") {
+		t.Fatalf("expected mount path under %q, got %q", ProjectedVolumePathPrefix, got)
+	}
+	// distinct pod identities must yield distinct mount paths so that a mount
+	// injected on a later (re)invocation does not collide with an earlier one
+	if buildVolumeMountPath("a") == buildVolumeMountPath("b") {
+		t.Fatalf("expected different mount paths for different pod identities")
+	}
+}
+
+// TestReinvocationDoesNotProduceDuplicateMountPath reproduces the v1.6.0
+// regression where a pod could end up with two volume mounts at the same
+// mountPath, which the API server rejects with
+// "spec.containers[*].volumeMounts[*].mountPath: must be unique". This happens
+// when metadata.name changes between the webhook invocation and its
+// reinvocation (reinvocationPolicy: IfNeeded), for example when another mutating
+// webhook populates the name. Because both the volume name and the mount path
+// are derived from the pod identity, a changed identity yields a unique volume
+// mount instead of one colliding at the previously injected path.
+func TestReinvocationDoesNotProduceDuplicateMountPath(t *testing.T) {
+	container := corev1.Container{Name: "app", Image: "image"}
+
+	// pass 1: metadata.name is empty during admission, identity derives from generateName
+	id1 := "dml-v1-expo-api-5864db4bfb- (prefix)"
+	container = addProjectedVolumeMount(container, buildVolumeName(id1), buildVolumeMountPath(id1))
+
+	// pass 2 (reinvocation): another webhook populated metadata.name
+	id2 := "dml-v1-expo-api-5864db4bfb-g4c9r"
+	container = addProjectedVolumeMount(container, buildVolumeName(id2), buildVolumeMountPath(id2))
+
+	mountPaths := sets.New[string]()
+	for _, vm := range container.VolumeMounts {
+		if mountPaths.Has(vm.MountPath) {
+			t.Fatalf("duplicate mountPath %q injected across webhook invocations", vm.MountPath)
+		}
+		mountPaths.Insert(vm.MountPath)
+	}
+
+	names := sets.New[string]()
+	for _, vm := range container.VolumeMounts {
+		if names.Has(vm.Name) {
+			t.Fatalf("duplicate volumeMount name %q injected across webhook invocations", vm.Name)
+		}
+		names.Insert(vm.Name)
+	}
+}
+
+// TestReinvocationWithStableIdentityIsIdempotent verifies that the common
+// reinvocation case, where the pod identity does not change between passes,
+// still results in exactly one injected volume mount.
+func TestReinvocationWithStableIdentityIsIdempotent(t *testing.T) {
+	container := corev1.Container{Name: "app", Image: "image"}
+	id := "dml-v1-expo-api-5864db4bfb-g4c9r"
+	container = addProjectedVolumeMount(container, buildVolumeName(id), buildVolumeMountPath(id))
+	container = addProjectedVolumeMount(container, buildVolumeName(id), buildVolumeMountPath(id))
+	if len(container.VolumeMounts) != 1 {
+		t.Fatalf("expected exactly one volume mount for a stable identity, got %d", len(container.VolumeMounts))
 	}
 }
 
@@ -904,7 +970,7 @@ func TestMutateContainers(t *testing.T) {
 				},
 				{
 					Name:  AzureFederatedTokenFileEnvVar,
-					Value: filepath.Join(VolumeMountPath, TokenFilePath),
+					Value: filepath.Join(testVolumeMountPath, TokenFilePath),
 				},
 				{
 					Name:  AzureAuthorityHostEnvVar,
@@ -914,7 +980,7 @@ func TestMutateContainers(t *testing.T) {
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      testVolumeName,
-					MountPath: VolumeMountPath,
+					MountPath: testVolumeMountPath,
 					ReadOnly:  true,
 				},
 			},
@@ -943,7 +1009,7 @@ func TestMutateContainers(t *testing.T) {
 				},
 				{
 					Name:  AzureFederatedTokenFileEnvVar,
-					Value: filepath.Join(VolumeMountPath, TokenFilePath),
+					Value: filepath.Join(testVolumeMountPath, TokenFilePath),
 				},
 				{
 					Name:  AzureAuthorityHostEnvVar,
@@ -953,7 +1019,7 @@ func TestMutateContainers(t *testing.T) {
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      testVolumeName,
-					MountPath: VolumeMountPath,
+					MountPath: testVolumeMountPath,
 					ReadOnly:  true,
 				},
 			},
@@ -973,7 +1039,7 @@ func TestMutateContainers(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			containers := m.mutateContainers(test.containers, azureClientID, azureTenantID, test.skipContainers, false, testVolumeName)
+			containers := m.mutateContainers(test.containers, azureClientID, azureTenantID, test.skipContainers, false, testVolumeName, testVolumeMountPath)
 			if !reflect.DeepEqual(containers, test.expectedContainers) {
 				t.Errorf("expected: %v, got: %v", test.expectedContainers, test.containers)
 			}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -253,9 +253,12 @@ func validateMutatedPod(ctx context.Context, f *framework.Framework, pod *corev1
 		for _, volumeMount := range container.VolumeMounts {
 			if strings.HasPrefix(volumeMount.Name, projectedVolumeNamePrefix) {
 				found = true
+				// the mount path is suffixed with a per-pod hash, so assert on the
+				// base path prefix and match the remaining fields exactly
+				gomega.Expect(volumeMount.MountPath).To(gomega.HavePrefix(volumeMountPath + "/"))
 				gomega.Expect(volumeMount).To(gomega.Equal(corev1.VolumeMount{
 					Name:      volumeMount.Name,
-					MountPath: volumeMountPath,
+					MountPath: volumeMount.MountPath,
 					ReadOnly:  true,
 				}))
 				break
@@ -291,7 +294,16 @@ func validateMutatedPod(ctx context.Context, f *framework.Framework, pod *corev1
 	if len(withoutSkipContainers) > 0 {
 		err := e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace)
 		framework.ExpectNoError(err, "failed to start pod %s", pod.Name)
-		_ = e2epod.ExecCommandInContainer(f, pod.Name, withoutSkipContainers[0].Name, "cat", filepath.Join(volumeMountPath, tokenFilePath))
+		// the token mount path is suffixed with a per-pod hash, so read it back
+		// from the mutated container rather than assuming the base path
+		tokenMountPath := volumeMountPath
+		for _, volumeMount := range withoutSkipContainers[0].VolumeMounts {
+			if strings.HasPrefix(volumeMount.Name, projectedVolumeNamePrefix) {
+				tokenMountPath = volumeMount.MountPath
+				break
+			}
+		}
+		_ = e2epod.ExecCommandInContainer(f, pod.Name, withoutSkipContainers[0].Name, "cat", filepath.Join(tokenMountPath, tokenFilePath))
 	}
 }
 


### PR DESCRIPTION
The projected token volume name and mount path derive from the pod identity, which can change between the webhook invocation and its reinvocation (e.g. another mutating webhook populates metadata.name under reinvocationPolicy: IfNeeded). The mount path was a fixed constant, so a second mount was appended at the same path and rejected by the API server with "spec.containers[*].volumeMounts[*].mountPath: must be unique".

Derive the mount path from the same pod identity hash so it is unique per pod and cannot collide across invocations.

BREAKING CHANGE: the projected service account token mount path now includes a per-pod hash segment
(/var/run/secrets/azure/wi/<hash>/token/azure-identity-token). Workloads using the Azure SDK are unaffected since they read AZURE_FEDERATED_TOKEN_FILE; workloads that hardcode the token path must be updated.

**Reason for Change**:
<!-- What does this PR improve or fix in Azure AD Workload Identity? Why is it needed? -->

<!--
**Is this a deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/azure-workload-identity/tree/main/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release.
-->

<!--
**Are you making changes to the Helm chart?**
Helm chart is auto-generated in Azure AD Workload Identity. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see https://github.com/Azure/azure-workload-identity/blob/main/third_party/open-policy-agent/gatekeeper/helmify/static/README.md#contributing-changes for modifying the Helm chart.
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [ ] no

**Notes for Reviewers**:
