### PR TITLE
fix(webhook): preserve unknown pod fields

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/validation"
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/discovery"
@@ -163,6 +164,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) (respons
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
+	oldPod := pod.DeepCopy()
 
 	podName := pod.GetName()
 	if podName == "" {
@@ -239,12 +241,33 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) (respons
 
 	m.addProjectedVolume(pod, serviceAccountTokenExpiration, volumeName, podUsingCustomTokenEndpoint)
 
-	marshaledPod, err := json.Marshal(pod)
+	return mutatedPodResponse(req.Object.Raw, oldPod, pod, logger)
+}
+
+// mutatedPodResponse preserves fields unknown to our Pod type: controller-runtime's raw-to-typed diff still loses them under version skew.
+// A strategic diff isolates our typed changes so only those changes are applied to the raw object.
+func mutatedPodResponse(raw []byte, old, mutated *corev1.Pod, logger mlog.Logger) admission.Response {
+	oldJSON, err := json.Marshal(old)
 	if err != nil {
-		logger.Error("failed to marshal pod object", err)
+		logger.Error("failed to marshal original pod", err)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+	newJSON, err := json.Marshal(mutated)
+	if err != nil {
+		logger.Error("failed to marshal mutated pod", err)
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	patch, err := strategicpatch.CreateTwoWayMergePatch(oldJSON, newJSON, corev1.Pod{})
+	if err != nil {
+		logger.Error("failed to create strategic merge patch", err)
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	patchedPod, err := strategicpatch.StrategicMergePatch(raw, patch, corev1.Pod{})
+	if err != nil {
+		logger.Error("failed to apply strategic merge patch", err)
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponseFromRaw(raw, patchedPod)
 }
 
 // mutateContainers mutates the containers by injecting the projected

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -892,10 +892,8 @@ func TestHandle(t *testing.T) {
 				"add /spec/containers/0/env",
 				"add /spec/containers/0/volumeMounts",
 				"add /spec/initContainers/0/env",
-				"add /spec/initContainers/0/resources",
 				"add /spec/initContainers/0/volumeMounts",
 				"add /spec/volumes",
-				"add /status",
 			},
 		},
 		{
@@ -1015,13 +1013,9 @@ func TestHandle(t *testing.T) {
 			config:        &config.Config{TenantID: "tenantID"},
 			audience:      DefaultAudience,
 			expectedPatches: []string{
-				"add /metadata/creationTimestamp",
 				"add /spec/containers/0/env",
-				"add /spec/containers/0/resources",
 				"add /spec/containers/0/volumeMounts",
 				"add /spec/volumes",
-				"add /status",
-				"remove /spec/resources",
 			},
 		},
 		{
@@ -1031,13 +1025,9 @@ func TestHandle(t *testing.T) {
 			config:        &config.Config{TenantID: "tenantID"},
 			audience:      DefaultAudience,
 			expectedPatches: []string{
-				"add /metadata/creationTimestamp",
 				"add /spec/containers/0/env",
-				"add /spec/containers/0/resources",
 				"add /spec/containers/0/volumeMounts",
 				"add /spec/volumes",
-				"add /status",
-				"remove /panda",
 			},
 		},
 	}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -791,46 +792,253 @@ func TestHandle(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		rawPod        []byte
-		clientObjects []client.Object
-		readerObjects []client.Object
+		name                string
+		rawPod              []byte
+		clientObjects       []client.Object
+		readerObjects       []client.Object
+		config              *config.Config
+		audience            string
+		azureAuthorityHost  string
+		proxyImage          string
+		proxyInitImage      string
+		useNativeSidecar    bool
+		customTokenEndpoint customTokenEndpointConfig
+		expectedPatches     []string
 	}{
 		{
-			name:          "service account in cache",
-			rawPod:        newPodRaw("pod", "ns1", "sa", nil, nil, false),
+			name:               "service account in cache",
+			rawPod:             newPodRaw("pod", "ns1", "sa", nil, nil, false),
+			clientObjects:      serviceAccounts,
+			config:             &config.Config{TenantID: "tenantID"},
+			audience:           DefaultAudience,
+			azureAuthorityHost: "https://login.microsoftonline.com/",
+			expectedPatches: []string{
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/initContainers/0/env",
+				"add /spec/initContainers/0/volumeMounts",
+				"add /spec/volumes",
+			},
+		},
+		{
+			name:               "service account not in cache",
+			rawPod:             newPodRaw("pod", "ns1", "sa", nil, nil, false),
+			readerObjects:      serviceAccounts,
+			config:             &config.Config{TenantID: "tenantID"},
+			audience:           DefaultAudience,
+			azureAuthorityHost: "https://login.microsoftonline.com/",
+			expectedPatches: []string{
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/initContainers/0/env",
+				"add /spec/initContainers/0/volumeMounts",
+				"add /spec/volumes",
+			},
+		},
+		{
+			name:               "default service account in cache",
+			rawPod:             newPodRaw("pod", "ns1", "", nil, nil, false),
+			clientObjects:      serviceAccounts,
+			config:             &config.Config{TenantID: "tenantID"},
+			audience:           DefaultAudience,
+			azureAuthorityHost: "https://login.microsoftonline.com/",
+			expectedPatches: []string{
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/initContainers/0/env",
+				"add /spec/initContainers/0/volumeMounts",
+				"add /spec/volumes",
+			},
+		},
+		{
+			name:               "default service account not in cache",
+			rawPod:             newPodRaw("pod", "ns1", "", nil, nil, false),
+			readerObjects:      serviceAccounts,
+			config:             &config.Config{TenantID: "tenantID"},
+			audience:           DefaultAudience,
+			azureAuthorityHost: "https://login.microsoftonline.com/",
+			expectedPatches: []string{
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/initContainers/0/env",
+				"add /spec/initContainers/0/volumeMounts",
+				"add /spec/volumes",
+			},
+		},
+		{
+			name: "skip container and pod token expiration",
+			rawPod: newPodRaw("pod", "ns1", "sa", map[string]string{UseWorkloadIdentityLabel: "true"}, map[string]string{
+				ServiceAccountTokenExpiryAnnotation: "7200",
+				SkipContainersAnnotation:            "init-container",
+			}, false),
+			clientObjects:      serviceAccounts,
+			config:             &config.Config{TenantID: "tenantID"},
+			audience:           DefaultAudience,
+			azureAuthorityHost: "https://login.microsoftonline.com/",
+			expectedPatches: []string{
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/volumes",
+			},
+		},
+		{
+			name:               "pod has the required label, restart policy in init container",
+			rawPod:             []byte(`{"metadata":{"name":"pod","namespace":"ns1","creationTimestamp":null,"labels":{"azure.workload.identity/use":"true"}},"spec":{"initContainers":[{"name":"init-container","image":"init-container-image","restartPolicy":"Always"}],"containers":[{"name":"container","image":"image","resources":{}}]}}`),
+			clientObjects:      serviceAccounts,
+			config:             &config.Config{TenantID: "tenantID"},
+			audience:           DefaultAudience,
+			azureAuthorityHost: "https://login.microsoftonline.com/",
+			expectedPatches: []string{
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/initContainers/0/env",
+				"add /spec/initContainers/0/resources",
+				"add /spec/initContainers/0/volumeMounts",
+				"add /spec/volumes",
+				"add /status",
+			},
+		},
+		{
+			name: "proxy init and sidecar",
+			rawPod: newPodRaw("pod", "ns1", "sa", map[string]string{UseWorkloadIdentityLabel: "true"}, map[string]string{
+				InjectProxySidecarAnnotation: "true",
+				ProxySidecarPortAnnotation:   "9000",
+			}, false),
+			clientObjects:      serviceAccounts,
+			config:             &config.Config{TenantID: "tenantID"},
+			audience:           DefaultAudience,
+			azureAuthorityHost: "https://login.microsoftonline.com/",
+			proxyImage:         "proxy:test",
+			proxyInitImage:     "proxy-init:test",
+			expectedPatches: []string{
+				"add /spec/containers/0/args",
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/imagePullPolicy",
+				"add /spec/containers/0/lifecycle",
+				"add /spec/containers/0/ports",
+				"add /spec/containers/0/securityContext",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/containers/1",
+				"add /spec/initContainers/0/env",
+				"add /spec/initContainers/0/volumeMounts",
+				"add /spec/initContainers/1",
+				"add /spec/volumes",
+				"replace /spec/containers/0/image",
+				"replace /spec/containers/0/name",
+			},
+		},
+		{
+			name: "native proxy sidecar",
+			rawPod: newPodRaw("pod", "ns1", "sa", map[string]string{UseWorkloadIdentityLabel: "true"}, map[string]string{
+				InjectProxySidecarAnnotation: "true",
+			}, false),
+			clientObjects:      serviceAccounts,
+			config:             &config.Config{TenantID: "tenantID"},
+			audience:           DefaultAudience,
+			azureAuthorityHost: "https://login.microsoftonline.com/",
+			proxyImage:         "proxy:test",
+			proxyInitImage:     "proxy-init:test",
+			useNativeSidecar:   true,
+			expectedPatches: []string{
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/initContainers/0/args",
+				"add /spec/initContainers/0/env",
+				"add /spec/initContainers/0/imagePullPolicy",
+				"add /spec/initContainers/0/lifecycle",
+				"add /spec/initContainers/0/ports",
+				"add /spec/initContainers/0/restartPolicy",
+				"add /spec/initContainers/0/securityContext",
+				"add /spec/initContainers/0/volumeMounts",
+				"add /spec/initContainers/1",
+				"add /spec/initContainers/2",
+				"add /spec/volumes",
+				"replace /spec/initContainers/0/image",
+				"replace /spec/initContainers/0/name",
+			},
+		},
+		{
+			name: "custom token endpoint with CA config map",
+			rawPod: newPodRaw("pod", "ns1", "sa", map[string]string{UseWorkloadIdentityLabel: "true"}, map[string]string{
+				"azure.workload.identity/use-custom": "true",
+			}, false),
 			clientObjects: serviceAccounts,
-			readerObjects: nil,
+			config: &config.Config{
+				TenantID:                       "tenantID",
+				AzureKubernetesTokenProxy:      "https://token.proxy",
+				AzureKubernetesSNIName:         "server.name",
+				AzureKubernetesCAConfigMapName: "ca-config",
+			},
+			audience:           DefaultAudience,
+			azureAuthorityHost: "https://login.microsoftonline.com/",
+			customTokenEndpoint: customTokenEndpointConfig{
+				enabled:    true,
+				annotation: "azure.workload.identity/use-custom",
+				audience:   "custom-audience",
+			},
+			expectedPatches: []string{
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/initContainers/0/env",
+				"add /spec/initContainers/0/volumeMounts",
+				"add /spec/volumes",
+			},
 		},
 		{
-			name:          "service account not in cache",
-			rawPod:        newPodRaw("pod", "ns1", "sa", nil, nil, false),
-			clientObjects: nil,
-			readerObjects: serviceAccounts,
-		},
-		{
-			name:          "default service account in cache",
-			rawPod:        newPodRaw("pod", "ns1", "", nil, nil, false),
+			name: "custom token endpoint with cluster trust bundle",
+			rawPod: newPodRaw("pod", "ns1", "sa", map[string]string{UseWorkloadIdentityLabel: "true"}, map[string]string{
+				"azure.workload.identity/use-custom": "true",
+			}, false),
 			clientObjects: serviceAccounts,
-			readerObjects: nil,
+			config: &config.Config{
+				TenantID:                       "tenantID",
+				AzureKubernetesCACTBSignerName: "example.com/signer",
+			},
+			audience: DefaultAudience,
+			customTokenEndpoint: customTokenEndpointConfig{
+				enabled:    true,
+				annotation: "azure.workload.identity/use-custom",
+				audience:   "custom-audience",
+			},
+			expectedPatches: []string{
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/initContainers/0/env",
+				"add /spec/initContainers/0/volumeMounts",
+				"add /spec/volumes",
+			},
 		},
 		{
-			name:          "default service account not in cache",
-			rawPod:        newPodRaw("pod", "ns1", "", nil, nil, false),
-			clientObjects: nil,
-			readerObjects: serviceAccounts,
-		},
-		{
-			name:          "pod has the required label, no warnings",
-			rawPod:        newPodRaw("pod", "ns1", "sa", map[string]string{UseWorkloadIdentityLabel: "true"}, nil, false),
+			name:          "pod-level resources from a newer Kubernetes API",
+			rawPod:        []byte(`{"metadata":{"name":"pod","namespace":"ns1"},"spec":{"serviceAccountName":"sa","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"200m","memory":"200Mi"}},"containers":[{"name":"container","image":"image"}]}}`),
 			clientObjects: serviceAccounts,
-			readerObjects: nil,
+			config:        &config.Config{TenantID: "tenantID"},
+			audience:      DefaultAudience,
+			expectedPatches: []string{
+				"add /metadata/creationTimestamp",
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/resources",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/volumes",
+				"add /status",
+				"remove /spec/resources",
+			},
 		},
 		{
-			name:          "pod has the required label, restart policy in init container",
-			rawPod:        []byte(`{"metadata":{"name":"pod","namespace":"ns1","creationTimestamp":null,"labels":{"azure.workload.identity/use":"true"}},"spec":{"initContainers":[{"name":"init-container","image":"init-container-image","restartPolicy":"Always"}],"containers":[{"name":"container","image":"image","resources":{}}]}}`),
+			name:          "unknown field",
+			rawPod:        []byte(`{"metadata":{"name":"pod","namespace":"ns1"},"spec":{"serviceAccountName":"sa","containers":[{"name":"container","image":"image"}]},"panda":"bamboo"}`),
 			clientObjects: serviceAccounts,
-			readerObjects: nil,
+			config:        &config.Config{TenantID: "tenantID"},
+			audience:      DefaultAudience,
+			expectedPatches: []string{
+				"add /metadata/creationTimestamp",
+				"add /spec/containers/0/env",
+				"add /spec/containers/0/resources",
+				"add /spec/containers/0/volumeMounts",
+				"add /spec/volumes",
+				"add /status",
+				"remove /panda",
+			},
 		},
 	}
 
@@ -841,10 +1049,16 @@ func TestHandle(t *testing.T) {
 			}
 
 			m := &podMutator{
-				client:  fake.NewClientBuilder().WithObjects(test.clientObjects...).Build(),
-				reader:  fake.NewClientBuilder().WithObjects(test.readerObjects...).Build(),
-				config:  &config.Config{TenantID: "tenantID"},
-				decoder: decoder,
+				client:              fake.NewClientBuilder().WithObjects(test.clientObjects...).Build(),
+				reader:              fake.NewClientBuilder().WithObjects(test.readerObjects...).Build(),
+				config:              test.config,
+				decoder:             decoder,
+				audience:            test.audience,
+				azureAuthorityHost:  test.azureAuthorityHost,
+				proxyImage:          test.proxyImage,
+				proxyInitImage:      test.proxyInitImage,
+				useNativeSidecar:    test.useNativeSidecar,
+				customTokenEndpoint: test.customTokenEndpoint,
 			}
 
 			req := atypes.Request{
@@ -864,10 +1078,14 @@ func TestHandle(t *testing.T) {
 			if !resp.Allowed {
 				t.Fatalf("expected to be allowed")
 			}
+			gotPatches := make([]string, 0, len(resp.Patches))
 			for _, patch := range resp.Patches {
-				if patch.Operation == "remove" {
-					t.Errorf("expected no remove patches, got: %v", patch)
-				}
+				gotPatches = append(gotPatches, fmt.Sprintf("%s %s", patch.Operation, patch.Path))
+			}
+			sort.Strings(gotPatches)
+			sort.Strings(test.expectedPatches)
+			if !reflect.DeepEqual(gotPatches, test.expectedPatches) {
+				t.Errorf("expected patches:\n%v\ngot:\n%v", test.expectedPatches, gotPatches)
 			}
 		})
 	}


### PR DESCRIPTION
**Reason for Change**:

Preserve fields unknown to the webhook's Pod type across Kubernetes version skew.

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:

Fixes #1751

**Please answer the following questions with yes/no**:

Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

- [ ] yes
- [x] no

**Notes for Reviewers**:

Applies only the typed mutation delta to the raw Pod using a strategic merge patch.